### PR TITLE
Improve auto documentation generation

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 setuptools
 sphinx_autodoc_typehints
+sphinx_rtd_theme

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -10,9 +10,9 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+import os
+import sys
+sys.path.insert(0, os.path.abspath('../..'))
 
 master_doc = "index"
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -54,6 +54,9 @@ templates_path = ["_templates"]
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = []
 
+# Generate the API documentation when building
+autosummary_generate = True
+autodoc_member_order = 'bysource'
 
 # -- Options for HTML output -------------------------------------------------
 


### PR DESCRIPTION
Hi

Here is an incremental step towards having the read-the-docs autosummary working. 

First, thank you for `docs/Makefile` and `docs/requirements.txt` those made getting things going so much easier. Incidentally, I encountered a missing dependency, it seems the sphinx_rtd_theme used to be automatically required, but is no longer, so I added it here.

The main issue with the autosummary was that `make html` couldn't see the dynamo library at all. 
```
WARNING: autodoc: failed to import module 'dynamo'; the following exception was raised:
No module named 'dynamo'
```
With a minor adjustment to the sys.path in the docs/source/config.py and it can now see the module and some of the methods are listed in the API docs. 

There are still several namespaces that are not listing methods. There are still many warnings coming out of `make html`. I encourage you to have a look through them. Perhaps some of the missing methods are just because of a naming mismatch between the documentation reference and the actual code.