### PR TITLE
Fix module_path to be relative to the files, not the cwd.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,7 +12,9 @@
 #
 import os
 import sys
-sys.path.insert(0, os.path.abspath('../..'))
+
+module_path = os.path.join(os.path.dirname(__file__), '../..')
+sys.path.insert(0, os.path.abspath(module_path))
 
 master_doc = "index"
 


### PR DESCRIPTION
This makes it include the right path regardless of what the current
working directory is.

This is important because the read-the-docs build and the Makefile have
different expectations of what the current working directory is.