### PR TITLE
VectorField function documentation and API change

### DIFF
--- a/dynamo/vectorfield/topography.py
+++ b/dynamo/vectorfield/topography.py
@@ -631,16 +631,16 @@ def VectorField(
             Number of cores to run the ddhodge function. If cores is set to be > 1, multiprocessing will be used to parallel
             the ddhodge calculation.
         copy:
-            Whether to return a new deep copy of adata instead of updating adata object passed in arguments and returning None.
+            Whether to return a new deep copy of `adata` instead of updating `adata` object passed in arguments and returning `None`.
         kwargs:
             Other additional parameters passed to the vectorfield class.
 
     Returns
     -------
-        adata:
-            If copy and return_vf_object arguments are set to False, `AnnData` object that is updated with the `VecFld` dictionary in the `uns` attribute.
-            If return_vf_object is set to True, then a vector field class object is returned.
-            If copy is set to True, a deep copy of the original adata object is returned.
+        adata: :class:`Union[anndata.AnnData, base_vectorfield]`
+            If `copy` and `return_vf_object` arguments are set to False, `annData` object is updated with the `VecFld` dictionary in the `uns` attribute.
+            If `return_vf_object` is set to True, then a vector field class object is returned.
+            If `copy` is set to True, a deep copy of the original `adata` object is returned.
     """
     if copy:
         adata = adata.deepcopy()


### PR DESCRIPTION
Add type check for VectorField function in topography.py; add a copy parameter to let user choose whether to deep copy and return a new AnnData object.
**Important**: Now if copy and return_vf_object are set to False, then None is returned and adata is updated. This is different from previous versions.
Minor style change with default PEP8 (included in flake tool: PEP8+pyflake): line break (default is line width=80), blank lines between functions, etc. In future we may have a setup.cfg for PEP style setting. (Do we have something similar now?) https://flake8.pycqa.org/en/2.5.5/config.html
I can revert these style changes  if you want the previous version.