### PR TITLE
fix some vectorField warning due to assigning values to a copy of slice from df

### DIFF
--- a/dynamo/dynamo_logger.py
+++ b/dynamo/dynamo_logger.py
@@ -25,7 +25,7 @@ def format_logging_message(msg, logging_level, indent_level=1, indent_space_num=
         prefix += "?"
     elif logging_level == logging.CRITICAL:
         prefix += "!!"
-    new_msg = prefix + " " + msg
+    new_msg = prefix + " " + str(msg)
     return new_msg
 
 

--- a/dynamo/vectorfield/topography.py
+++ b/dynamo/vectorfield/topography.py
@@ -825,8 +825,8 @@ def VectorField(
         logger.info_insert_adata(inlier_prob, adata_attr="obs")
 
         adata.obs[control_point], adata.obs[inlier_prob] = False, np.nan
-        adata.obs[control_point][vf_dict["ctrl_idx"]] = True
-        adata.obs[inlier_prob][valid_ids] = vf_dict["P"].flatten()
+        adata[vf_dict["ctrl_idx"]].obs[control_point] = True
+        adata[valid_ids].obs[inlier_prob] = vf_dict["P"].flatten()
 
     # angles between observed velocity and that predicted by vector field across cells:
     cell_angels = np.zeros(adata.n_obs)

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,5 +1,5 @@
-import dynamo.tools
 from dynamo import LoggerManager
+import dynamo.tools
 import dynamo as dyn
 import pytest
 import time
@@ -34,7 +34,7 @@ def test_vectorField_logger():
     adata = dyn.sample_data.zebrafish()
     dyn.pp.recipe_monocle(adata, num_dim=20, exprs_frac_max=0.005)
     dyn.tl.dynamics(adata, model="stochastic", cores=8)
-    dyn.tl.reduceDimension(adata, enforce=True)
+    dyn.tl.reduceDimension(adata, n_pca_components=5, enforce=True)
     dyn.tl.cell_velocities(adata, basis="pca")
     dyn.vf.VectorField(adata, basis="pca", M=100)
     dyn.vf.VectorField(adata, basis="pca", M=100)


### PR DESCRIPTION
Fix the following warning:


```
|-----> <insert> control_point_pca to obs in AnnData Object.
|-----> <insert> inlier_prob_pca to obs in AnnData Object.
/Users/mashiro/.local/lib/python3.8/site-packages/dynamo_release-0.95.2-py3.8.egg/dynamo/vectorfield/topography.py:827: SettingWithCopyWarning: 
A value is trying to be set on a copy of a slice from a DataFrame

See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy
  adata.obs[control_point][vf_dict["ctrl_idx"]] = True
/Users/mashiro/.local/lib/python3.8/site-packages/dynamo_release-0.95.2-py3.8.egg/dynamo/vectorfield/topography.py:828: SettingWithCopyWarning: 
A value is trying to be set on a copy of a slice from a DataFrame
```