### PR TITLE
Make loggerManager more usable; quick fix state graph enumerate issue

### DIFF
--- a/dynamo/dynamo_logger.py
+++ b/dynamo/dynamo_logger.py
@@ -194,7 +194,9 @@ class LoggerManager:
         return Logger("dynamo-temp-timer-logger")
 
     @staticmethod
-    def progress_logger(generator, logger, progress_name=""):
+    def progress_logger(generator, logger=None, progress_name=""):
+        if logger is None:
+            logger = LoggerManager.get_temp_timer_logger()
         iterator = iter(generator)
         logger.log_time()
         i = 0

--- a/dynamo/prediction/state_graph.py
+++ b/dynamo/prediction/state_graph.py
@@ -106,9 +106,7 @@ def state_graph(
         logger.finish_progress(progress_name="KDTree computation")
         vf_dict = adata.uns["VecFld_" + basis]
 
-        for i, cur_grp in LoggerManager.progress_logger(
-            enumerate(uniq_grp), LoggerManager.get_temp_timer_logger(), progress_name="iterate groups:"
-        ):
+        for i, cur_grp in enumerate(LoggerManager.progress_logger(uniq_grp, progress_name="iterate groups")):
             init_cells = adata.obs_names[groups == cur_grp]
             if sample_num is not None:
                 cell_num = np.min((sample_num, len(init_cells)))

--- a/dynamo/tools/cell_velocities.py
+++ b/dynamo/tools/cell_velocities.py
@@ -482,10 +482,7 @@ def cell_velocities(
     if preserve_len:
         basis_len, high_len = np.linalg.norm(delta_X, axis=1), np.linalg.norm(V, axis=1)
         scaler = np.nanmedian(basis_len) / np.nanmedian(high_len)
-        temp_logger = LoggerManager.get_temp_timer_logger()
-        for i in LoggerManager.progress_logger(
-            range(adata.n_obs), temp_logger, progress_name="rescaling velocity norm"
-        ):
+        for i in LoggerManager.progress_logger(range(adata.n_obs), progress_name="rescaling velocity norm"):
             idx = T[i].indices
             high_len_ = high_len[idx]
             T_i = T[i].data
@@ -814,10 +811,8 @@ def kernels_from_velocyto_scvelo(
         vals = []
 
     delta_X = np.zeros((n, X_embedding.shape[1]))
-    temp_logger = LoggerManager.get_temp_timer_logger()
     for i in LoggerManager.progress_logger(
         range(n),
-        temp_logger,
         progress_name=f"calculating transition matrix via {kernel} kernel with {transform} transform.",
     ):
         velocity = V[i, :]  # project V to pca space
@@ -890,9 +885,8 @@ def projection_with_transition_matrix(n, T, X_embedding):
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        temp_logger = LoggerManager.get_temp_timer_logger()
         for i in LoggerManager.progress_logger(
-            range(n), temp_logger, progress_name=f"projecting velocity vector to low dimensional embedding"
+            range(n), progress_name=f"projecting velocity vector to low dimensional embedding"
         ):
             idx = T[i].indices
             diff_emb = X_embedding[idx] - X_embedding[i, None]

--- a/dynamo/vectorfield/utils.py
+++ b/dynamo/vectorfield/utils.py
@@ -597,9 +597,7 @@ def compute_curvature(vf, f_jac, X, formula=2):
     v, _, _, a = compute_acceleration(vf, f_jac, X, return_all=True)
     cur_mat = np.zeros((n, X.shape[1])) if formula == 2 else None
 
-    for i in LoggerManager.progress_logger(
-        range(n), LoggerManager.get_temp_timer_logger(), progress_name="Calculating curvature"
-    ):
+    for i in LoggerManager.progress_logger(range(n), progress_name="Calculating curvature"):
         if formula == 1:
             curv[i] = curvature_1(a[i], v[i])
         elif formula == 2:

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -68,6 +68,7 @@ def test_zebrafish_topography_tutorial_logger():
     dyn.pp.top_pca_genes(adata)
     top_pca_genes = adata.var.index[adata.var.top_pca_genes]
     dyn.vf.jacobian(adata, regulators=top_pca_genes, effectors=top_pca_genes)
+    dyn.pd.state_graph(adata, group="Cell_type", basis="pca", method="vf")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`for item in LoggerManager.progress_logger(generator):` 
A generator argument is enough for progress_logger to generate a logger and thus users do not need to explicitly pass a logger object to progress_logger now.