### PR TITLE
Fix read the docs issue

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,7 +18,7 @@ python:
   install:
     - method: pip
       path: .
-    #   extra_requirements:
-    #     - docs
+      extra_requirements:
+        - docs
     # - method: setuptools
     #   path: package

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,7 +8,17 @@ build:
 sphinx:
   configuration: docs/source/conf.py
 
+# python:
+#     version: 3.7
+#     install:
+#         - requirements: docs/requirements.txt
+
 python:
-    version: 3.7
-    install:
-        - requirements: docs/requirements.txt
+  version: 3.7
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs
+    - method: setuptools
+      path: package

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,7 +18,7 @@ python:
   install:
     - method: pip
       path: .
-      extra_requirements:
-        - docs
-    - method: setuptools
-      path: package
+    #   extra_requirements:
+    #     - docs
+    # - method: setuptools
+    #   path: package

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,65 +1,68 @@
 [build-system]
-requires = ['flit']
 build-backend = 'flit.buildapi'
+requires = ['flit']
 
 [tool.flit.metadata]
-module = 'dynamo'
+requires-extra = { doc = ['docutils', 'setuptools',
+'sphinx==3.1.1',
+'sphinx-rtd-theme==0.5.0'
+'sphinx_autodoc_typehints',
+'nbsphinx'], test = ['pytest', 'sympy>=1.4'], spatial = ['pysal>2.0.0'], dimension_reduction = ['fitsne>=1.0.1'], bigdata_visualization = ["datashader>=0.9.0", "bokeh>=1.4.0", "holoviews>=1.9.2"] }
 author = 'Xiaojie Qiu, Yan Zhang, Ke Ni'
 author-email = 'xqiu.sc@gmail.com'
-home-page = 'https://github.com/aristoteleo/dynamo-release'
-license = 'BSD'
-description-file = 'README.md'
-requires-python = '>=3.6'
-requires = ['numpy>=1.18.1',
-            'pandas>=0.25.1',
-            'scipy>=1.0',
-            'scikit-learn>=0.19.1',
-            'cvxopt>=1.2.3',
-            'anndata==0.7.5',
-            'loompy>=3.0.5',
-            'matplotlib>=3.1.0',
-            'trimap>=1.0.11',
-            'setuptools',
-            'numdifftools>=0.9.39',
-            'umap-learn>=0.5.1',
-            'hdbscan>=0.8.26',
-            'PATSY>=0.5.1',
-            'statsmodels>=0.9.0',
-            'numba>=0.46.0',
-            'seaborn>=0.9.0',
-            'colorcet>=2.0.1',
-            'networkx',
-            'tqdm',
-            'python-igraph>=0.7.1',
-            'pynndescent>=0.5.2',
-            'joblib',
-            'setuptools']
-requires-extra = { doc = ['docutils'], test = ['pytest', 'sympy>=1.4'], spatial = ['pysal>2.0.0'], dimension_reduction = ['fitsne>=1.0.1'], bigdata_visualization = ["datashader>=0.9.0", "bokeh>=1.4.0", "holoviews>=1.9.2"] }
-keywords = 'dynamo scslam-seq scrna-seq velocity rna protein vector-field potential-landscape'
 classifiers = [
-	'License :: OSI Approved :: BSD License',
-	'Development Status :: 5 - Production/Stable',
-	'Intended Audience :: Science/Research',
-	'Natural Language :: English',
-	'Programming Language :: Python :: 3.6',
-	'Programming Language :: Python :: 3.7',
-	'Programming Language :: Python :: 3.8'
+  'License :: OSI Approved :: BSD License',
+  'Development Status :: 5 - Production/Stable',
+  'Intended Audience :: Science/Research',
+  'Natural Language :: English',
+  'Programming Language :: Python :: 3.6',
+  'Programming Language :: Python :: 3.7',
+  'Programming Language :: Python :: 3.8',
 ]
+description-file = 'README.md'
+home-page = 'https://github.com/aristoteleo/dynamo-release'
+keywords = 'dynamo scslam-seq scrna-seq velocity rna protein vector-field potential-landscape'
+license = 'BSD'
+module = 'dynamo'
+requires = [
+  'numpy>=1.18.1',
+  'pandas>=0.25.1',
+  'scipy>=1.0',
+  'scikit-learn>=0.19.1',
+  'cvxopt>=1.2.3',
+  'anndata==0.7.5',
+  'loompy>=3.0.5',
+  'matplotlib>=3.1.0',
+  'trimap>=1.0.11',
+  'setuptools',
+  'numdifftools>=0.9.39',
+  'umap-learn>=0.5.1',
+  'hdbscan>=0.8.26',
+  'PATSY>=0.5.1',
+  'statsmodels>=0.9.0',
+  'numba>=0.46.0',
+  'seaborn>=0.9.0',
+  'colorcet>=2.0.1',
+  'networkx',
+  'tqdm',
+  'python-igraph>=0.7.1',
+  'pynndescent>=0.5.2',
+  'joblib',
+  'setuptools',
+]
+requires-python = '>=3.6'
 
 [tool.flit.sdist]
 exclude = [
-    'dynamo/tests',
-    'setup.py',
+  'dynamo/tests',
+  'setup.py',
 ]
 
 [tool.coverage.run]
-source = ['dynamo']
 omit = ['*/tests/*']
-
+source = ['dynamo']
 
 [tool.black]
-line-length = 80
-include = '\.pyi?$'
 exclude = '''
 /(
     \.git
@@ -73,3 +76,5 @@ exclude = '''
   | dist
 )/
 '''
+include = '\.pyi?$'
+line-length = 80

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,10 +46,11 @@ requires = [
   'setuptools',
 ]
 requires-python = '>=3.6'
+
 [tool.flit.metadata.requires-extra]
 bigdata_visualization = ["datashader>=0.9.0", "bokeh>=1.4.0", "holoviews>=1.9.2"]
 dimension_reduction = ['fitsne>=1.0.1']
-doc = [
+docs = [
   'docutils',
   'setuptools',
   'sphinx==3.1.1',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,11 +3,6 @@ build-backend = 'flit.buildapi'
 requires = ['flit']
 
 [tool.flit.metadata]
-requires-extra = { doc = ['docutils', 'setuptools',
-'sphinx==3.1.1',
-'sphinx-rtd-theme==0.5.0'
-'sphinx_autodoc_typehints',
-'nbsphinx'], test = ['pytest', 'sympy>=1.4'], spatial = ['pysal>2.0.0'], dimension_reduction = ['fitsne>=1.0.1'], bigdata_visualization = ["datashader>=0.9.0", "bokeh>=1.4.0", "holoviews>=1.9.2"] }
 author = 'Xiaojie Qiu, Yan Zhang, Ke Ni'
 author-email = 'xqiu.sc@gmail.com'
 classifiers = [
@@ -51,6 +46,19 @@ requires = [
   'setuptools',
 ]
 requires-python = '>=3.6'
+[tool.flit.metadata.requires-extra]
+bigdata_visualization = ["datashader>=0.9.0", "bokeh>=1.4.0", "holoviews>=1.9.2"]
+dimension_reduction = ['fitsne>=1.0.1']
+doc = [
+  'docutils',
+  'setuptools',
+  'sphinx==3.1.1',
+  'sphinx-rtd-theme==0.5.0',
+  'sphinx_autodoc_typehints',
+  'nbsphinx',
+]
+spatial = ['pysal>2.0.0']
+test = ['pytest', 'sympy>=1.4']
 
 [tool.flit.sdist]
 exclude = [


### PR DESCRIPTION
It is not stable to use path of dynamo folder for import as one of our presumptions. 
Now I explicitly requires read the docs to install dynamo and write all requirements in pyproject.toml. We can delete requirements.txt in ./docs in future. For debugging read the docs, team members can register their own read the docs account and test via the web interface.