### PR TITLE
fix data_io downloading issue when ts (total size) is unknown

### DIFF
--- a/dynamo/dynamo_logger.py
+++ b/dynamo/dynamo_logger.py
@@ -222,7 +222,12 @@ class Logger:
         """
         if self.report_hook_percent_state is None:
             self.report_hook_percent_state = 0
+
+        if ts == -1:
+            return
+
         cur_percent = rs * bn / ts
+
         if cur_percent - self.report_hook_percent_state > 0.01:
             self.report_progress(count=rs * bn, total=ts)
             self.report_hook_percent_state = cur_percent


### PR DESCRIPTION
According to python documentation, if total size is unknown, ts param in report hook function is -1. This behavior causes a huge amount of prints when ts=-1. `dyn.sample_data.zebrafish()` does not have ts in my case today (python=3.9).