### PR TITLE
fix query_W matrix construction issue mentioned in #289

### DIFF
--- a/dynamo/external/hodge.py
+++ b/dynamo/external/hodge.py
@@ -218,14 +218,13 @@ def ddhodge(
         query_idx = np.array(list(set(np.arange(adata.n_obs)).difference(cell_idx)))
         query_data = X_data_full[query_idx, :]
 
-        # construct nbrs of query points
+        # construct nbrs of query points based on two types of nbrs: from NNDescent (pynndescent) or NearestNeighbors
         if hasattr(nbrs, "kneighbors"):
             dist, query_nbrs_idx = nbrs.kneighbors(query_data)
         elif hasattr(nbrs, "query"):
             query_nbrs_idx, dist = nbrs.query(query_data, k=nbrs.n_neighbors)
 
         k = query_nbrs_idx.shape[1]
-
         query_W_row = np.repeat(np.arange(len(query_idx)), k)
         query_W_col = query_nbrs_idx.flatten()
 

--- a/dynamo/tools/graph_calculus.py
+++ b/dynamo/tools/graph_calculus.py
@@ -1,3 +1,4 @@
+from typing import Callable, Union
 import numpy as np
 import scipy.sparse as sp
 from scipy.linalg import qr
@@ -10,15 +11,15 @@ from ..dynamo_logger import main_info, main_warning
 def graphize_velocity(
     V,
     X,
-    nbrs_idx=None,
-    dists=None,
-    k=30,
-    normalize_v=False,
-    scale_by_dist=False,
-    E_func=None,
-    use_sparse=False,
-    return_nbrs=False,
-):
+    nbrs_idx: Union[np.array, list] = None,
+    dists: np.array = None,
+    k: int = 30,
+    normalize_v: bool = False,
+    scale_by_dist: bool = False,
+    E_func: Union[str, Callable] = None,
+    use_sparse: bool = False,
+    return_nbrs: bool = False,
+) -> tuple:
     """
         The function generates a graph based on the velocity data. The flow from i- to j-th
         node is returned as the edge matrix E[i, j], and E[i, j] = -E[j, i].
@@ -40,6 +41,8 @@ def graphize_velocity(
             If a string is passed, there are two options:
                 'sqrt': the numpy.sqrt square root function;
                 'exp': the numpy.exp exponential function.
+        return_nbrs:
+            returns a neighbor object if this arg is true. A neighbor object is from k_nearest_neighbors and may be from NNDescent (pynndescent) or NearestNeighbors.
 
     Returns
     -------

--- a/dynamo/tools/utils.py
+++ b/dynamo/tools/utils.py
@@ -125,17 +125,12 @@ def k_nearest_neighbors(
     n_jobs: int = -1,
     return_nbrs: bool = False,
 ):
-    """_summary_
+    """Compute k nearest neighbors on X
 
     Parameters
     ----------
     return_nbrs:
         returns a neighbor object if this arg is true, by default False. A neighbor object is from k_nearest_neighbors and may be from NNDescent (pynndescent) or NearestNeighbors.
-
-    Returns
-    -------
-    _type_
-        _description_
     """
     n, d = np.atleast_2d(X).shape
     if n > int(pynn_num) and d > pynn_dim:

--- a/dynamo/tools/utils.py
+++ b/dynamo/tools/utils.py
@@ -115,7 +115,15 @@ def nearest_neighbors(coord, coords, k=5):
 
 
 def k_nearest_neighbors(
-    X, k, exclude_self=True, knn_dim=10, pynn_num=2e5, pynn_dim=2, pynn_rand_state=19491001, n_jobs=-1
+    X,
+    k,
+    exclude_self=True,
+    knn_dim=10,
+    pynn_num=2e5,
+    pynn_dim=2,
+    pynn_rand_state=19491001,
+    n_jobs=-1,
+    return_nbrs=False,
 ):
     n, d = np.atleast_2d(X).shape
     if n > int(pynn_num) and d > pynn_dim:
@@ -138,6 +146,8 @@ def k_nearest_neighbors(
     if exclude_self:
         nbrs_idx = nbrs_idx[:, 1:]
         dists = dists[:, 1:]
+    if return_nbrs:
+        return nbrs_idx, dists, nbrs
     return nbrs_idx, dists
 
 

--- a/dynamo/tools/utils.py
+++ b/dynamo/tools/utils.py
@@ -116,15 +116,27 @@ def nearest_neighbors(coord, coords, k=5):
 
 def k_nearest_neighbors(
     X,
-    k,
-    exclude_self=True,
-    knn_dim=10,
-    pynn_num=2e5,
-    pynn_dim=2,
-    pynn_rand_state=19491001,
-    n_jobs=-1,
-    return_nbrs=False,
+    k: int,
+    exclude_self: bool = True,
+    knn_dim: int = 10,
+    pynn_num: int = int(2e5),
+    pynn_dim: int = 2,
+    pynn_rand_state: int = 19491001,
+    n_jobs: int = -1,
+    return_nbrs: bool = False,
 ):
+    """_summary_
+
+    Parameters
+    ----------
+    return_nbrs:
+        returns a neighbor object if this arg is true, by default False. A neighbor object is from k_nearest_neighbors and may be from NNDescent (pynndescent) or NearestNeighbors.
+
+    Returns
+    -------
+    _type_
+        _description_
+    """
     n, d = np.atleast_2d(X).shape
     if n > int(pynn_num) and d > pynn_dim:
         from pynndescent import NNDescent


### PR DESCRIPTION
Issue #289 mentioned an issue related to query W construction. `graphize_veclocity` did not return nbrs object after last API change. Now it returns nbrs with a new argument "return_nbrs", so that the neighbors of query points can be calculated via nbrs object.

2 API change: `return_nbrs=False` argument added to `graphize_velocity` and `k_nearest_neighbors`, which returns an extra nbrs object when this arg is true. This change will not affect existing calls to the two functions above because the default value is false.

