### PR TITLE
refactor space, stack_colors in scatters and add docs

### DIFF
--- a/dynamo/plot/space.py
+++ b/dynamo/plot/space.py
@@ -46,7 +46,7 @@ def space(
             A list of cmaps for mapping each gene's values according to a type of cmap when stacking gene colors on the same subplot. The order of each gene's cmap corresponds to the order in genes.
         color: `string` (default: `ntr`)
             Any or any list of column names or gene names, etc. that will be used for coloring cells. If `color` is not None, stack_genes will be disabled automatically because `color` can contain non numerical values.
-        space: `str`
+        space_key: `str`
             The key to space coordinates.
         stack_genes:
             whether to show all gene plots on the same plot

--- a/dynamo/plot/space.py
+++ b/dynamo/plot/space.py
@@ -42,6 +42,8 @@ def space(
         genes:
             The gene list that will be used to plot the gene expression on the same scatter plot. Each gene will have a
             different color. Can be a single gene name string and we will convert it to a list.
+        gene_cmaps:
+            A list of cmaps for mapping each gene's values according to a type of cmap when stacking gene colors on the same subplot. The order of each gene's cmap corresponds to the order in genes.
         color: `string` (default: `ntr`)
             Any or any list of column names or gene names, etc. that will be used for coloring cells. If `color` is not None, stack_genes will be disabled automatically because `color` can contain non numerical values.
         space: `str`


### PR DESCRIPTION
- more docs regarding space's `gene_cmaps` argument
- support stack_colors for those color in obs/vars with non-numeric values

One example is included below where X is not the actual spatial transcriptomics coordinates, but set to gene values as coordinates in zebrafish dataset.
![Screen Shot 2022-03-11 at 2 09 11 PM](https://user-images.githubusercontent.com/12120524/157935401-ab857fd3-1d90-47e2-a991-a9e2f13296eb.png)
