### PR TITLE
support setting a resolution for vectorfield clustering

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/python/black
-    rev: 20.8b1
+    rev: 22.6.0
     hooks:
     - id: black
       args: [--line-length=120]
@@ -14,7 +14,7 @@ repos:
 #         args: [--max-line-length=120]
 
 -   repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         args: ["--profile", "black", "--filter-files"]

--- a/dynamo/vectorfield/clustering.py
+++ b/dynamo/vectorfield/clustering.py
@@ -86,18 +86,6 @@ def cluster_field(
     logger.log_time()
     adata = copy_adata(adata) if copy else adata
 
-    if method in ["louvain", "leiden"]:
-        try:
-            from cdlib import algorithms
-
-            "leiden" in dir(algorithms)
-
-        except ImportError:
-            raise ImportError(
-                "You need to install the excellent package `cdlib` if you want to use louvain or leiden "
-                "for clustering."
-            )
-
     features = list(
         set(features).intersection(["speed", "potential", "divergence", "acceleration", "curvature", "curl"])
     )
@@ -155,13 +143,6 @@ def cluster_field(
         # X = (X - X.min(0)) / X.ptp(0)
         X = (X - X.mean(0)) / X.std(0)
 
-    # add the resolution parameter to the kwargs so that it could be passed to downstream clustering function calls()
-    kwargs.update(
-        {
-            "resolution": resolution,
-        }
-    )
-
     if method in ["hdbscan", "kmeans"]:
         if method == "hdbscan":
             key = "field_hdbscan"
@@ -202,26 +183,11 @@ def cluster_field(
         adata.obsp["vf_feature_knn"] = graph
 
         if method == "leiden":
-            leiden(
-                adata,
-                adj_matrix_key="vf_feature_knn",
-                result_key="field_leiden",
-                **kwargs
-            )
+            leiden(adata, resolution=resolution, adj_matrix_key="vf_feature_knn", result_key="field_leiden", **kwargs)
         elif method == "louvain":
-            louvain(
-                adata,
-                adj_matrix_key="vf_feature_knn",
-                result_key="field_louvain",
-                **kwargs
-            )
+            louvain(adata, resolution=resolution, adj_matrix_key="vf_feature_knn", result_key="field_louvain", **kwargs)
         elif method == "infomap":
-            infomap(
-                adata,
-                adj_matrix_key="vf_feature_knn",
-                result_key="field_infomap",
-                **kwargs
-            )
+            infomap(adata, adj_matrix_key="vf_feature_knn", result_key="field_infomap", **kwargs)
 
     logger.finish_progress(progress_name="clustering_field")
 
@@ -264,18 +230,6 @@ def streamline_clusters(
     """
 
     import matplotlib.pyplot as plt
-
-    if method in ["louvain", "leiden"]:
-        try:
-            from cdlib import algorithms
-
-            "leiden" in dir(algorithms)
-
-        except ImportError:
-            raise ImportError(
-                "You need to install the excellent package `cdlib` if you want to use louvain or leiden "
-                "for clustering."
-            )
 
     vf_dict, func = vecfld_from_adata(adata, basis=basis)
     grid_kwargs_dict = {

--- a/dynamo/vectorfield/clustering.py
+++ b/dynamo/vectorfield/clustering.py
@@ -30,6 +30,7 @@ def cluster_field(
     method="leiden",
     cores=1,
     copy=False,
+    resolution=1.0,
     **kwargs,
 ):
     """Cluster cells based on vector field features.
@@ -71,6 +72,8 @@ def cluster_field(
         ``-1`` means using all processors.
     copy:
         Whether to return a new deep copy of `adata` instead of updating `adata` object passed in arguments.
+    resolution:
+        Clustering resolution, higher values yield more fine-grained clusters.
     kwargs:
         Any additional arguments that will be passed to either kmeans, hdbscan, louvain or leiden clustering algorithms.
 
@@ -152,6 +155,13 @@ def cluster_field(
         # X = (X - X.min(0)) / X.ptp(0)
         X = (X - X.mean(0)) / X.std(0)
 
+    # add the resolution parameter to the kwargs so that it could be passed to downstream clustering function calls()
+    kwargs.update(
+        {
+            "resolution": resolution,
+        }
+    )
+
     if method in ["hdbscan", "kmeans"]:
         if method == "hdbscan":
             key = "field_hdbscan"
@@ -196,18 +206,21 @@ def cluster_field(
                 adata,
                 adj_matrix_key="vf_feature_knn",
                 result_key="field_leiden",
+                **kwargs
             )
         elif method == "louvain":
             louvain(
                 adata,
                 adj_matrix_key="vf_feature_knn",
                 result_key="field_louvain",
+                **kwargs
             )
         elif method == "infomap":
             infomap(
                 adata,
                 adj_matrix_key="vf_feature_knn",
                 result_key="field_infomap",
+                **kwargs
             )
 
     logger.finish_progress(progress_name="clustering_field")


### PR DESCRIPTION
Changes:

1. add **kwargs for the leiden(), louvain(), infomap() function calls in dyn.vf.cluster_field(),  otherwise the function can only use default resolution settings

2. add a `resolution` parameter explicitly so users would not bother passing it via kwargs 

After this change, 
`tools.clustering.leiden(), tools.clustering.louvain(), tools.clustering.infomap()` automatically get ` `resolution`` by its caller `vf.cluster_field()`

`tools.clustering.cluster_community() ` automatically gets `resolution` from `**kwargs` passed by its caller `tools.clustering.leiden(), tools.clustering.louvain(), tools.clustering.infomap()`

`tools.clustering.cluster_community_from_graph()` automatically gets `resolution` from `**kwargs` passed by its caller `tools.clustering.cluster_community()`