### PR TITLE
Update moments.py: bug fix

### DIFF
--- a/dynamo/tools/moments.py
+++ b/dynamo/tools/moments.py
@@ -190,7 +190,11 @@ def moments(
     layers.sort(reverse=True)  # ensure we get M_us, M_tn, etc (instead of M_su or M_nt).
     for i, layer in enumerate(layers):
         layer_x = adata.layers[layer].copy()
-        layer_x_group = np.where([layer in x for x in [only_splicing, only_labeling, splicing_and_labeling]])[0][0]
+        matched_x_group = np.where([layer in x for x in [only_splicing, only_labeling, splicing_and_labeling]])
+        if len(matched_x_group[0]) == 0:
+            logger.warning(f"layer {layer} is not in any of the {only_splicing, only_labeling, splicing_and_labeling} groups, skipping...")
+            continue
+        layer_x_group = matched_x_group[0][0]
         layer_x = inverse_norm(adata, layer_x)
 
         if mapper[layer] not in adata.layers.keys():
@@ -200,9 +204,13 @@ def moments(
                 else (conn.dot(layer_x), conn)
             )
         for layer2 in layers[i:]:
+            matched_group_indices = np.where([layer2 in x for x in [only_splicing, only_labeling, splicing_and_labeling]])
+            if len(matched_group_indices[0]) == 0:
+                logger.warning(f"layer {layer2} is not in any of the {only_splicing, only_labeling, splicing_and_labeling} groups, skipping...")
+                continue
             layer_y = adata.layers[layer2].copy()
 
-            layer_y_group = np.where([layer2 in x for x in [only_splicing, only_labeling, splicing_and_labeling]])[0][0]
+            layer_y_group = matched_group_indices[0][0]
             # don't calculate 2 moments among uu, ul, su, sl -
             # they should be time-dependent moments and
             # those calculations are model specific

--- a/dynamo/tools/moments.py
+++ b/dynamo/tools/moments.py
@@ -190,11 +190,11 @@ def moments(
     layers.sort(reverse=True)  # ensure we get M_us, M_tn, etc (instead of M_su or M_nt).
     for i, layer in enumerate(layers):
         layer_x = adata.layers[layer].copy()
-        matched_x_group = np.where([layer in x for x in [only_splicing, only_labeling, splicing_and_labeling]])
-        if len(matched_x_group[0]) == 0:
+        matched_x_group_indices = np.where([layer in x for x in [only_splicing, only_labeling, splicing_and_labeling]])
+        if len(matched_x_group_indices[0]) == 0:
             logger.warning(f"layer {layer} is not in any of the {only_splicing, only_labeling, splicing_and_labeling} groups, skipping...")
             continue
-        layer_x_group = matched_x_group[0][0]
+        layer_x_group = matched_x_group_indices[0][0]
         layer_x = inverse_norm(adata, layer_x)
 
         if mapper[layer] not in adata.layers.keys():
@@ -204,13 +204,13 @@ def moments(
                 else (conn.dot(layer_x), conn)
             )
         for layer2 in layers[i:]:
-            matched_group_indices = np.where([layer2 in x for x in [only_splicing, only_labeling, splicing_and_labeling]])
-            if len(matched_group_indices[0]) == 0:
+            matched_y_group_indices = np.where([layer2 in x for x in [only_splicing, only_labeling, splicing_and_labeling]])
+            if len(matched_y_group_indices[0]) == 0:
                 logger.warning(f"layer {layer2} is not in any of the {only_splicing, only_labeling, splicing_and_labeling} groups, skipping...")
                 continue
             layer_y = adata.layers[layer2].copy()
 
-            layer_y_group = matched_group_indices[0][0]
+            layer_y_group = matched_y_group_indices[0][0]
             # don't calculate 2 moments among uu, ul, su, sl -
             # they should be time-dependent moments and
             # those calculations are model specific


### PR DESCRIPTION
Without this fix: if there are any key starting with X_ that is not in the groups defined for splicing/unsplicing/new/total (e.g. X_Mu generated by other packages shown below), moments function will raise [0][0] dimensionality issue.

Fixed version:
<img width="1034" alt="image" src="https://user-images.githubusercontent.com/12120524/224743614-145bd5ea-69e7-4010-a73e-e63702f68d74.png">
