### PR TITLE
fix the bug of pca mean not saving

### DIFF
--- a/dynamo/preprocessing/utils.py
+++ b/dynamo/preprocessing/utils.py
@@ -864,6 +864,7 @@ def _truncatedSVD_with_center(
         random_state=random_state,
     )
     X_pca = result_dict["X_pca"]
+    fit.mean_ = mean.A1.flatten()
     fit.components_ = result_dict["components_"]
     fit.explained_variance_ratio_ = result_dict[
         "explained_variance_ratio_"]


### PR DESCRIPTION
Fix the bug in the optimized sparse input PCA function that PCA mean matrix is not correctly saved.