### PR TITLE
fix additional issues regarding regress out

### DIFF
--- a/dynamo/preprocessing/Preprocessor.py
+++ b/dynamo/preprocessing/Preprocessor.py
@@ -486,9 +486,7 @@ class Preprocessor:
 
         # recipe monocle log1p all raw data in normalize_by_cells (dynamo version), so we do not need extra log1p transform.
         self.use_log1p = False
-        self.regress_out_kwargs = update_dict(
-            {"obs_key": [], "gene_selection_key": "use_for_pca"}, self.regress_out_kwargs
-        )
+        self.regress_out_kwargs = update_dict({"obs_keys": []}, self.regress_out_kwargs)
         self.pca = pca
         self.pca_kwargs = {"pca_key": "X_pca"}
 
@@ -526,15 +524,14 @@ class Preprocessor:
 
         self._log1p(adata)  # Always done in normalization process. Do we need this process explictly?
 
-        if len(self.regress_out_kwargs["obs_key"]) > 0:
+        if len(self.regress_out_kwargs["obs_keys"]) > 0:
             self._regress_out(adata)
-            self.pca_kwargs.update({"layer": "regress_out"})
 
         self._pca(adata)
 
         temp_logger.finish_progress(progress_name="preprocess")
 
-    def config_seurat_recipe(self, adata: AnnData, regress_out_obs_keys: List[str] = []) -> None:
+    def config_seurat_recipe(self, adata: AnnData) -> None:
         """Automatically configure the preprocessor for using the seurat style recipe.
 
         Args:
@@ -549,9 +546,7 @@ class Preprocessor:
         self.filter_genes_by_outliers_kwargs = {"shared_count": 20}
         self.use_log1p = True
         self.log1p_kwargs = {"layers": ["X"]}
-        self.regress_out_kwargs = update_dict(
-            {"obs_key": [], "gene_selection_key": "use_for_pca"}, self.regress_out_kwargs
-        )
+        self.regress_out_kwargs = update_dict({"obs_keys": []}, self.regress_out_kwargs)
 
     def preprocess_adata_seurat(
         self, adata: AnnData, tkey: Optional[str] = None, experiment_type: Optional[str] = None
@@ -577,9 +572,8 @@ class Preprocessor:
         self._normalize_by_cells(adata)
         self._select_genes(adata)
         self._log1p(adata)
-        if len(self.regress_out_kwargs["obs_key"]) > 0:
+        if len(self.regress_out_kwargs["obs_keys"]) > 0:
             self._regress_out(adata)
-            self.pca_kwargs.update({"layer": "regress_out"})
         self._pca(adata)
         temp_logger.finish_progress(progress_name="preprocess by seurat recipe")
 
@@ -602,9 +596,7 @@ class Preprocessor:
         }
         self.select_genes_kwargs = {"inplace": True}
         self.sctransform_kwargs = {"layers": raw_layers, "n_top_genes": 2000}
-        self.regress_out_kwargs = update_dict(
-            {"obs_key": [], "gene_selection_key": "use_for_pca"}, self.regress_out_kwargs
-        )
+        self.regress_out_kwargs = update_dict({"obs_keys": []}, self.regress_out_kwargs)
         self.pca_kwargs = {"pca_key": "X_pca", "n_pca_components": 50}
 
     def preprocess_adata_sctransform(
@@ -634,9 +626,8 @@ class Preprocessor:
         # TODO: if inplace in select_genes is True, the following subset is unnecessary.
         adata._inplace_subset_var(adata.var["use_for_pca"])
         self.sctransform(adata, **self.sctransform_kwargs)
-        if len(self.regress_out_kwargs["obs_key"]) > 0:
+        if len(self.regress_out_kwargs["obs_keys"]) > 0:
             self._regress_out(adata)
-            self.pca_kwargs.update({"layer": "regress_out"})
         self._pca(adata)
 
         temp_logger.finish_progress(progress_name="preprocess by sctransform recipe")
@@ -657,9 +648,7 @@ class Preprocessor:
         # select layers in adata to be normalized
         normalize_layers = DKM.get_raw_data_layers(adata)
         self.normalize_selected_genes_kwargs = {"layers": normalize_layers, "copy": False}
-        self.regress_out_kwargs = update_dict(
-            {"obs_key": [], "gene_selection_key": "use_for_pca"}, self.regress_out_kwargs
-        )
+        self.regress_out_kwargs = update_dict({"obs_keys": []}, self.regress_out_kwargs)
         self.pca_kwargs = {"pca_key": "X_pca", "n_pca_components": 50}
         self.use_log1p = False
 
@@ -685,9 +674,8 @@ class Preprocessor:
 
         self._select_genes(adata)
         self._normalize_selected_genes(adata)
-        if len(self.regress_out_kwargs["obs_key"]) > 0:
+        if len(self.regress_out_kwargs["obs_keys"]) > 0:
             self._regress_out(adata)
-            self.pca_kwargs.update({"layer": "regress_out"})
 
         self._pca(adata)
 
@@ -712,10 +700,7 @@ class Preprocessor:
         self.normalize_selected_genes = normalize_layers_pearson_residuals
 
         self.normalize_selected_genes_kwargs = {"layers": ["X"], "copy": False}
-        self.regress_out_kwargs = update_dict(
-            {"obs_key": [], "gene_selection_key": "use_for_pca"}, self.regress_out_kwargs
-        )
-
+        self.regress_out_kwargs = update_dict({"obs_keys": []}, self.regress_out_kwargs)
         self.pca_kwargs = {"pca_key": "X_pca", "n_pca_components": 50}
         self.use_log1p = False
 
@@ -743,9 +728,8 @@ class Preprocessor:
         self._normalize_by_cells(adata)
         adata.X = X_copy
         self._normalize_selected_genes(adata)
-        if len(self.regress_out_kwargs["obs_key"]) > 0:
+        if len(self.regress_out_kwargs["obs_keys"]) > 0:
             self._regress_out(adata)
-            self.pca_kwargs.update({"layer": "regress_out"})
 
         self.pca(adata, **self.pca_kwargs)
         temp_logger.finish_progress(progress_name="preprocess by monocle pearson residual recipe")

--- a/dynamo/preprocessing/preprocessor_utils.py
+++ b/dynamo/preprocessing/preprocessor_utils.py
@@ -1538,7 +1538,7 @@ def pca_selected_genes_wrapper(
 def regress_out_parallel(
     adata: AnnData,
     layer: str = DKM.X_LAYER,
-    obs_key: Optional[List[str]] = None,
+    obs_keys: Optional[List[str]] = None,
     gene_selection_key: Optional[str] = None,
     n_cores: Optional[int] = None,
     obsm_store_key: str = "X_regress_out",
@@ -1548,20 +1548,22 @@ def regress_out_parallel(
     Args:
         adata: an AnnData object. Feature matrix of shape (n_samples, n_features).
         layer: the layer to regress out. Defaults to "X".
-        obs_key: List of observation keys to be removed.
+        obs_keys: List of observation keys to be removed.
         gene_selection_key: the key in adata.var that contains boolean for showing genes` filtering results.
             For example, "use_for_pca" is selected then it will regress out only for the genes that are True
             for "use_for_pca". This input will decrease processing time of regressing out data.
         n_cores: Change this to the number of cores on your system for parallel computing. Default to be None.
         obsm_store_key: the key to store the regress out result. Defaults to "X_regress_out".
     """
+    main_debug("regress out %s by multiprocessing..." % obs_keys)
+    main_log_time()
 
-    if len(obs_key) < 1:
+    if len(obs_keys) < 1:
         main_warning("No variable to regress out")
         return
 
     if gene_selection_key is None:
-        x_prev = DKM.select_layer_data(adata, layer)
+        regressor = DKM.select_layer_data(adata, layer)
     else:
         if gene_selection_key not in adata.var.keys():
             raise ValueError(str(gene_selection_key) + " is not a key in adata.var")
@@ -1570,75 +1572,48 @@ def regress_out_parallel(
             raise ValueError(str(gene_selection_key) + " is not a boolean")
 
         subset_adata = adata[:, adata.var.loc[:, gene_selection_key]]
-        x_prev = DKM.select_layer_data(subset_adata, layer)
+        regressor = DKM.select_layer_data(subset_adata, layer)
 
-    x_prev = x_prev.toarray()
-    if x_prev.shape[1] < 10000:
-        y_new = x_prev.copy()  # for the cases when variables are more than 1.
+    import itertools
+    import os
 
-        for key in obs_key:
-            if key not in adata.obs.keys():
-                main_warning("No %s in adata.obs.keys" % key)
-                continue
+    if issparse(regressor):
+        regressor = regressor.toarray()
 
-            # Select the variables to remove
-            x_remove = adata.obs[key].to_numpy().reshape(-1, 1)
+    if n_cores is None:
+        n_cores = os.cpu_count() // 2  # Use half of available cores as the default.
 
-            # Predict the effects of the variables to remove
-            y_pred = regress_out_chunk(x_remove, y_new)
+    # Split the input data into chunks for parallel processing
+    chunk_size = min(1000, regressor.shape[1] // n_cores + 1)
+    chunk_len = regressor.shape[1] // chunk_size
+    regressor_chunks = np.array_split(regressor, chunk_len, axis=1)
 
-            # Remove the effects of the variables from the target variable
-            y_new -= y_pred
+    # Select the variables to remove
+    remove = adata.obs[obs_keys].to_numpy()
 
-        # Predict the residuals after removing the effects of the variables and save to "X_regress_out"
-        res = regress_out_chunk(x_prev, y_new)
-    else:
-        if n_cores is None:
-            import os
+    res = _parallel_wrapper(regress_out_chunk_helper, zip(itertools.repeat(remove), regressor_chunks), n_cores)
 
-            n_cores = os.cpu_count() / 2  # Use half of available cores as the default.
+    # Remove the effects of the variables from the target variable
+    residuals = regressor - np.hstack(res)
 
-        import multiprocessing
-
-        ctx = multiprocessing.get_context("fork")
-
-        regress_val = np.zeros((x_prev.shape[0], x_prev.shape[1]))
-        # Split the input data into chunks for parallel processing
-        chunk_size = x_prev.shape[1] // n_cores
-
-        chunks = [x_prev[:, i * chunk_size : (i + 1) * chunk_size] for i in range(n_cores - 1)]
-        chunks.append(x_prev[:, (n_cores - 1) * chunk_size :])
-
-        # Create a pool of work processes
-        pool = ctx.Pool(n_cores)
-
-        for key in obs_key:
-            if key not in adata.obs.keys():
-                main_warning("No %s in adata.obs.keys" % key)
-                continue
-
-            x_remove = [adata.obs[key].to_numpy().reshape(-1, 1)] * n_cores
-            results = pool.starmap(regress_out_chunk, zip(x_remove, chunks))
-            regress_val += np.hstack(results)
-
-        # Remove the effects of the variables from the target variable
-        residuals = x_prev - regress_val
-
-        chunks_res = [residuals[:, i * chunk_size : (i + 1) * chunk_size] for i in range(n_cores - 1)]
-        chunks_res.append(residuals[:, (n_cores - 1) * chunk_size :])
-
-        x_prev = [x_prev] * n_cores
-
-        results = pool.starmap(regress_out_chunk, zip(x_prev, chunks_res))
-        pool.close()
-        pool.join()
-
-        res = np.hstack(results)
-
-    adata.obsm[obsm_store_key] = res
+    DKM.set_layer_data(adata, layer, residuals)
+    main_finish_progress("regress out")
 
 
-def regress_out_chunk(
+def regress_out_chunk_helper(args):
+    """A helper function for each regressout chunk.
+
+    Args:
+        args: list of arguments that is used in _regress_out_chunk.
+
+    Returns:
+        numpy array: predicted the effects of the variables calculated by _regress_out_chunk.
+    """
+    obs_feature, gene_expr = args
+    return _regress_out_chunk(obs_feature, gene_expr)
+
+
+def _regress_out_chunk(
     obs_feature: Union[np.ndarray, spmatrix, list], gene_expr: Union[np.ndarray, spmatrix, list]
 ) -> Union[np.ndarray, spmatrix, list]:
     """Perform a linear regression to remove the effects of cell features (percentage of mitochondria, etc.)
@@ -1657,3 +1632,26 @@ def regress_out_chunk(
 
     # Predict the effects of the variables to remove
     return reg.predict(obs_feature)
+
+
+def _parallel_wrapper(func: Callable, args_list, n_cores: Optional[int] = None):
+    """A wrapper for parallel operation to regress out of the input variables.
+
+    Args:
+        func: The function to be conducted the multiprocessing.
+        args_list: The iterable of arguments to be passed to the function.
+        n_cores: The number of CPU cores to be used for parallel processing. Default to be None.
+
+    Returns:
+        results: The list of results returned by the function for each element of the iterable.
+    """
+    import multiprocessing as mp
+
+    ctx = mp.get_context("fork")
+
+    with ctx.Pool(n_cores) as pool:
+        results = pool.map(func, args_list)
+        pool.close()
+        pool.join()
+
+    return results

--- a/dynamo/preprocessing/utils.py
+++ b/dynamo/preprocessing/utils.py
@@ -977,12 +977,6 @@ def pca(
                 X_data = adata.layers["X_spliced"][:, adata.var.use_for_pca.values]
             elif "protein" in layer:
                 X_data = adata.obsm["X_protein"]
-            elif "regress_out" in layer:
-                X_data = (
-                    adata.obsm["X_regress_out"]
-                    if "X_regress_out" in adata.obsm.keys()
-                    else adata.X[:, adata.var.use_for_pca.values]
-                )
             elif type(layer) is str:
                 X_data = adata.layers["X_" + layer][:, adata.var.use_for_pca.values]
             else:

--- a/dynamo/preprocessing/utils.py
+++ b/dynamo/preprocessing/utils.py
@@ -14,8 +14,8 @@ import scipy
 import scipy.sparse
 import statsmodels.api as sm
 from anndata import AnnData
-from scipy.sparse.linalg import LinearOperator, svds
 from scipy.sparse import csc_matrix, csr_matrix, issparse
+from scipy.sparse.linalg import LinearOperator, svds
 from sklearn.decomposition import PCA, TruncatedSVD
 from sklearn.utils import check_random_state
 from sklearn.utils.extmath import svd_flip
@@ -778,6 +778,7 @@ def decode(adata: anndata.AnnData) -> None:
 # ---------------------------------------------------------------------------------------------------
 # pca
 
+
 def _truncatedSVD_with_center(
     X: Union[csc_matrix, csr_matrix],
     n_components: int = 30,
@@ -844,7 +845,7 @@ def _truncatedSVD_with_center(
     )
 
     # Solve SVD without calculating individuals entries in LinearOperator.
-    U, Sigma, VT = svds(X_centered, solver='arpack', k=n_components, v0=v0)
+    U, Sigma, VT = svds(X_centered, solver="arpack", k=n_components, v0=v0)
     Sigma = Sigma[::-1]
     U, VT = svd_flip(U[:, ::-1], VT[::-1])
     X_transformed = U * Sigma
@@ -865,10 +866,10 @@ def _truncatedSVD_with_center(
     )
     X_pca = result_dict["X_pca"]
     fit.components_ = result_dict["components_"]
-    fit.explained_variance_ratio_ = result_dict[
-        "explained_variance_ratio_"]
+    fit.explained_variance_ratio_ = result_dict["explained_variance_ratio_"]
 
     return fit, X_pca
+
 
 def _pca_fit(
     X: np.ndarray,
@@ -893,7 +894,7 @@ def _pca_fit(
         A tuple containing two elements:
             - The fitted PCA object, which has a 'fit' and 'transform' method.
             - The transformed array X_pca of shape (n_samples, n_components).
-        """
+    """
     fit = pca_func(
         n_components=min(n_components, X.shape[1] - 1),
         **kwargs,
@@ -1007,6 +1008,7 @@ def pca(
 
     if use_incremental_PCA:
         from sklearn.decomposition import IncrementalPCA
+
         fit, X_pca = _pca_fit(
             X_data,
             pca_func=IncrementalPCA,
@@ -1034,10 +1036,7 @@ def pca(
             # data. It only performs SVD decomposition, which is the second part
             # in our _truncatedSVD_with_center function.
             fit, X_pca = _pca_fit(
-                X_data,
-                pca_func=TruncatedSVD,
-                n_components=n_pca_components + 1,
-                random_state=random_state
+                X_data, pca_func=TruncatedSVD, n_components=n_pca_components + 1, random_state=random_state
             )
             # first columns is related to the total UMI (or library size)
             X_pca = X_pca[:, 1:]
@@ -1045,13 +1044,11 @@ def pca(
     adata.obsm[pca_key] = X_pca
     if use_incremental_PCA or adata.n_obs < use_truncated_SVD_threshold:
         adata.uns[pcs_key] = fit.components_.T
-        adata.uns[
-            "explained_variance_ratio_"] = fit.explained_variance_ratio_
+        adata.uns["explained_variance_ratio_"] = fit.explained_variance_ratio_
     else:
         # first columns is related to the total UMI (or library size)
         adata.uns[pcs_key] = fit.components_.T[:, 1:]
-        adata.uns[
-            "explained_variance_ratio_"] = fit.explained_variance_ratio_[1:]
+        adata.uns["explained_variance_ratio_"] = fit.explained_variance_ratio_[1:]
     adata.uns["pca_mean"] = fit.mean_ if hasattr(fit, "mean_") else None
 
     if return_all:

--- a/dynamo/preprocessing/utils.py
+++ b/dynamo/preprocessing/utils.py
@@ -907,7 +907,7 @@ def pca(
     adata: AnnData,
     X_data: np.ndarray = None,
     n_pca_components: int = 30,
-    pca_key: str = "X",
+    pca_key: str = "X_pca",
     pcs_key: str = "PCs",
     genes_to_append: Union[List[str], None] = None,
     layer: Union[List[str], str, None] = None,

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -236,7 +236,7 @@ def test_regress_out():
     dyn.pl.basic_stats(adata)
     dyn.pl.highest_frac_genes(adata)
 
-    preprocessor = Preprocessor(regress_out_kwargs={"obs_key": ["nCounts", "pMito"]})
+    preprocessor = Preprocessor(regress_out_kwargs={"obs_keys": ["nCounts", "pMito"]})
 
     preprocessor.preprocess_adata(adata, recipe="monocle")
     dyn.tl.reduceDimension(adata, basis="pca")
@@ -244,8 +244,27 @@ def test_regress_out():
     dyn.pl.umap(adata, color=celltype_key, figsize=figsize)
     print("The preprocess_adata() time difference is :", timeit.default_timer() - starttime)
 
+    ################TEST#################
+    # import timeit
+    # import scanpy as sc
+    #
+    # starttime = timeit.default_timer()
+    # scanpydata = adata.copy()
+    # sc.pp.regress_out(scanpydata, ["nCounts", "pMito", "umap_1"])
+    # print("The scanpy regress out time difference is :", timeit.default_timer() - starttime)
+    #
+    # starttime = timeit.default_timer()
+    # bdata = adata.copy()
+    # self.regress_out_kwargs = {"obs_keys": ["pMito", "nCounts", "umap_1"]}
+    # self._regress_out(bdata)
+    # print("The dynamo regress out time difference is :", timeit.default_timer() - starttime)
+    #
+    # starttime = timeit.default_timer()
+    # self.regress_out_kwargs = {"obs_keys": ["umap_1", "nCounts", "pMito"]}
+
 
 if __name__ == "__main__":
+    dyn.dynamo_logger.main_set_level("DEBUG")
     # test_is_nonnegative()
 
     # test_calc_dispersion_sparse()
@@ -265,5 +284,5 @@ if __name__ == "__main__":
     # test_highest_frac_genes_plot(adata.copy())
     # test_highest_frac_genes_plot_prefix_list(adata.copy())
     # test_recipe_monocle_feature_selection_layer_simple0()
-    # test_regress_out()
+    test_regress_out()
     pass


### PR DESCRIPTION
1. fix to use X_pca for pca instead of the X  in .obsm
2. fix documentations in `regress_out_chunk`
3. period after each line of documentation
4. For the n_cores, set default to be None. And then use half of available core as the default within the code.
5. timeit should be removed.
6. Do deep copy for comparison of prev and after variables.
7. Please note that there is no duplicate operation in linear regression. The function regress_out_chunk is called twice in this code because it is being used to perform two separate tasks.
      -  1st: is used to predict the effects of the variables that are being removed from the target variable y_new. 
      -  2nd: is used to predict the residuals after removing the effects of all the variables that were removed from the target variable.
