### PR TITLE
Skip inverse_norm in moments

### DIFF
--- a/dynamo/preprocessing/Preprocessor.py
+++ b/dynamo/preprocessing/Preprocessor.py
@@ -27,12 +27,10 @@ from .external import (
 from .gene_selection import select_genes_by_seurat_recipe, select_genes_monocle
 from .normalization import calc_sz_factor, normalize
 from .pca import pca
-from .QC import (
-    basic_stats,
-    filter_cells_by_outliers as monocle_filter_cells_by_outliers,
-    filter_genes_by_outliers as monocle_filter_genes_by_outliers,
-    regress_out_parallel,
-)
+from .QC import basic_stats
+from .QC import filter_cells_by_outliers as monocle_filter_cells_by_outliers
+from .QC import filter_genes_by_outliers as monocle_filter_genes_by_outliers
+from .QC import regress_out_parallel
 from .transform import Freeman_Tukey, log, log1p, log2
 from .utils import (
     _infer_labeling_experiment_type,
@@ -238,7 +236,8 @@ class Preprocessor:
         """
 
         adata.uns["pp"] = {}
-        adata.uns["pp"]["norm_method"] = None
+        adata.uns["pp"]["X_norm_method"] = None
+        adata.uns["pp"]["layers_norm_method"] = None
         self.basic_stats(adata)
         self.add_experiment_info(adata, tkey, experiment_type)
         main_info_insert_adata("tkey=%s" % tkey, "uns['pp']", indent_level=2)

--- a/dynamo/preprocessing/deprecated.py
+++ b/dynamo/preprocessing/deprecated.py
@@ -1,14 +1,15 @@
 import re
 import warnings
-from typing import Callable, List, Iterable, Optional, Tuple, Union
+from typing import Callable, Iterable, List, Optional, Tuple, Union
 
 try:
     from typing import Literal
 except ImportError:
     from typing_extensions import Literal
 
-import anndata
 import functools
+
+import anndata
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
@@ -17,10 +18,13 @@ from anndata import AnnData
 from scipy.sparse import csr_matrix, issparse
 from sklearn.decomposition import FastICA
 
-from ..configuration import DynamoAdataConfig, DynamoAdataKeyManager
+from ..configuration import DKM, DynamoAdataConfig, DynamoAdataKeyManager
 from ..dynamo_logger import (
+    LoggerManager,
+    main_debug,
     main_info,
     main_info_insert_adata_obsm,
+    main_warning,
 )
 from ..tools.utils import update_dict
 from ..utils import copy_adata
@@ -28,11 +32,7 @@ from .cell_cycle import cell_cycle_scores
 from .gene_selection import calc_dispersion_by_svr
 from .normalization import calc_sz_factor, get_sz_exprs, normalize_mat_monocle, sz_util
 from .pca import pca
-from .QC import (
-    basic_stats,
-    filter_genes_by_clusters,
-    filter_genes_by_outliers,
-)
+from .QC import basic_stats, filter_genes_by_clusters, filter_genes_by_outliers
 from .transform import _Freeman_Tukey
 from .utils import (
     _infer_labeling_experiment_type,
@@ -44,14 +44,11 @@ from .utils import (
     convert_layers2csr,
     detect_experiment_datatype,
     get_inrange_shared_counts_mask,
-    get_svr_filter,
     get_nan_or_inf_data_bool_mask,
+    get_svr_filter,
     merge_adata_attrs,
     unique_var_obs_adata,
 )
-
-from ..configuration import DKM
-from ..dynamo_logger import LoggerManager, main_debug, main_warning
 
 
 def deprecated(func):
@@ -61,9 +58,10 @@ def deprecated(func):
             f"{func.__name__} is deprecated and will be removed in a future release. "
             f"Please update your code to use the new replacement function.",
             category=DeprecationWarning,
-            stacklevel=2
+            stacklevel=2,
         )
         return func(*args, **kwargs)
+
     return wrapper
 
 
@@ -393,7 +391,9 @@ def _estimate_dispersion_legacy(
     return adata
 
 
-def _top_table_legacy(adata: AnnData, layer: str = "X", mode: Literal["dispersion", "gini"] = "dispersion") -> pd.DataFrame:
+def _top_table_legacy(
+    adata: AnnData, layer: str = "X", mode: Literal["dispersion", "gini"] = "dispersion"
+) -> pd.DataFrame:
     """Retrieve a table that contains gene names and other info whose dispersions/gini index are highest.
 
     This function is partly based on Monocle R package (https://github.com/cole-trapnell-lab/monocle3).
@@ -465,7 +465,9 @@ def _calc_mean_var_dispersion_general_mat_legacy(
         return _calc_mean_var_dispersion_sparse_legacy(data_mat, axis)
 
 
-def _calc_mean_var_dispersion_ndarray_legacy(data_mat: np.ndarray, axis: int = 0) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+def _calc_mean_var_dispersion_ndarray_legacy(
+    data_mat: np.ndarray, axis: int = 0
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
     """calculate mean, variance, and dispersion of a non-sparse matrix.
 
     Args:
@@ -488,7 +490,9 @@ def _calc_mean_var_dispersion_ndarray_legacy(data_mat: np.ndarray, axis: int = 0
     return mean.flatten(), var.flatten(), dispersion.flatten()
 
 
-def _calc_mean_var_dispersion_sparse_legacy(sparse_mat: csr_matrix, axis: int = 0) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+def _calc_mean_var_dispersion_sparse_legacy(
+    sparse_mat: csr_matrix, axis: int = 0
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
     """calculate mean, variance, and dispersion of a matrix.
 
     Args:
@@ -772,7 +776,8 @@ def _normalize_cell_expr_by_size_factors_legacy(
         else:
             adata.layers["X_" + layer] = CM
 
-        adata.uns["pp"]["norm_method"] = norm_method.__name__ if callable(norm_method) else norm_method
+        norm_method_key = "X_norm_method" if layer == DKM.X_LAYER else "layers_norm_method"
+        adata.uns["pp"][norm_method_key] = norm_method.__name__ if callable(norm_method) else norm_method
 
     return adata
 
@@ -1508,8 +1513,8 @@ def _recipe_monocle_legacy(
             if layer != "X":
                 logger.info_insert_adata("X_" + layer, "layers")
                 adata.layers["X_" + layer] = adata.layers[layer].copy()
-        logger.info_insert_adata("norm_method", "uns['pp']", indent_level=2)
-        adata.uns["pp"]["norm_method"] = None
+        logger.info_insert_adata("layers_norm_method", "uns['pp']", indent_level=2)
+        adata.uns["pp"]["layers_norm_method"] = None
 
     # only use genes pass filter (based on use_for_pca) to perform dimension reduction.
     if layer is None:

--- a/dynamo/preprocessing/transform.py
+++ b/dynamo/preprocessing/transform.py
@@ -12,10 +12,7 @@ from anndata import AnnData
 from scipy.sparse.base import issparse
 
 from ..configuration import DKM
-from ..dynamo_logger import (
-    main_debug,
-    main_info_insert_adata_uns,
-)
+from ..dynamo_logger import main_debug, main_info_insert_adata_uns
 from ..utils import copy_adata
 from .utils import is_integer_arr
 
@@ -271,8 +268,13 @@ def Freeman_Tukey(adata: AnnData, layers: list = [DKM.X_LAYER], copy: bool = Fal
     for layer in layers:
         Freeman_Tukey_adata_layer(_adata, layer=layer)
 
-    main_info_insert_adata_uns("pp.norm_method")
-    adata.uns["pp"]["norm_method"] = "Freeman_Tukey"
+        if layer == DKM.X_LAYER:
+            main_info_insert_adata_uns("pp.X_norm_method")
+            adata.uns["pp"]["X_norm_method"] = Freeman_Tukey.__name__
+        else:
+            main_info_insert_adata_uns("pp.layers_norm_method")
+            adata.uns["pp"]["layers_norm_method"] = Freeman_Tukey.__name__
+
     return _adata
 
 
@@ -296,8 +298,13 @@ def log(adata: AnnData, layers: list = [DKM.X_LAYER], copy: bool = False) -> Ann
     for layer in layers:
         log_adata_layer(_adata, layer=layer)
 
-    main_info_insert_adata_uns("pp.norm_method")
-    adata.uns["pp"]["norm_method"] = "log"
+        if layer == DKM.X_LAYER:
+            main_info_insert_adata_uns("pp.X_norm_method")
+            adata.uns["pp"]["X_norm_method"] = log.__name__
+        else:
+            main_info_insert_adata_uns("pp.layers_norm_method")
+            adata.uns["pp"]["layers_norm_method"] = log.__name__
+
     return _adata
 
 
@@ -321,8 +328,13 @@ def log1p(adata: AnnData, layers: list = [DKM.X_LAYER], copy: bool = False) -> A
     for layer in layers:
         log1p_adata_layer(_adata, layer=layer)
 
-    main_info_insert_adata_uns("pp.norm_method")
-    adata.uns["pp"]["norm_method"] = "log1p"
+        if layer == DKM.X_LAYER:
+            main_info_insert_adata_uns("pp.X_norm_method")
+            adata.uns["pp"]["X_norm_method"] = log1p.__name__
+        else:
+            main_info_insert_adata_uns("pp.layers_norm_method")
+            adata.uns["pp"]["layers_norm_method"] = log1p.__name__
+
     return _adata
 
 
@@ -346,8 +358,13 @@ def log2(adata: AnnData, layers: list = [DKM.X_LAYER], copy: bool = False) -> An
     for layer in layers:
         log2_adata_layer(_adata, layer=layer)
 
-    main_info_insert_adata_uns("pp.norm_method")
-    adata.uns["pp"]["norm_method"] = "log2"
+        if layer == DKM.X_LAYER:
+            main_info_insert_adata_uns("pp.X_norm_method")
+            adata.uns["pp"]["X_norm_method"] = log2.__name__
+        else:
+            main_info_insert_adata_uns("pp.layers_norm_method")
+            adata.uns["pp"]["layers_norm_method"] = log2.__name__
+
     return _adata
 
 

--- a/dynamo/tools/cell_velocities.py
+++ b/dynamo/tools/cell_velocities.py
@@ -319,10 +319,10 @@ def cell_velocities(
     V = V.A if sp.issparse(V) else V
     X = X.A if sp.issparse(X) else X
     finite_inds = get_finite_inds(V)
-    X, V = X[:, finite_inds], V[:, finite_inds]
 
-    if sum(finite_inds) != X.shape[0]:
+    if sum(finite_inds) != X.shape[1]:
         main_info(f"{X.shape[1] - sum(finite_inds)} genes are removed because of nan velocity values.")
+        X, V = X[:, finite_inds], V[:, finite_inds]
         if transition_genes is not None:  # if X, V is provided by the user, transition_genes will be None
             adata.var.loc[np.array(transition_genes)[~finite_inds], "use_for_transition"] = False
 

--- a/dynamo/tools/markers.py
+++ b/dynamo/tools/markers.py
@@ -667,25 +667,27 @@ def glm_degs(
                 f"When providing X_data, a list of genes name that corresponds to the columns of X_data "
                 f"must be provided"
             )
+
+    norm_method_key = "X_norm_method" if layer is None or layer == "X" else "layers_norm_method"
     if layer is None:
         if issparse(X_data):
             X_data.data = (
                 2**X_data.data - 1
-                if adata.uns["pp"]["norm_method"] == "log2"
+                if adata.uns["pp"][norm_method_key] == "log2"
                 else np.exp(X_data.data) - 1
-                if adata.uns["pp"]["norm_method"] == "log"
+                if adata.uns["pp"][norm_method_key] == "log"
                 else _Freeman_Tukey(X_data.data + 1, inverse=True)
-                if adata.uns["pp"]["norm_method"] == "Freeman_Tukey"
+                if adata.uns["pp"][norm_method_key] == "Freeman_Tukey"
                 else X_data.data
             )
         else:
             X_data = (
                 2**X_data - 1
-                if adata.uns["pp"]["norm_method"] == "log2"
+                if adata.uns["pp"][norm_method_key] == "log2"
                 else np.exp(X_data) - 1
-                if adata.uns["pp"]["norm_method"] == "log"
+                if adata.uns["pp"][norm_method_key] == "log"
                 else _Freeman_Tukey(X_data, inverse=True)
-                if adata.uns["pp"]["norm_method"] == "Freeman_Tukey"
+                if adata.uns["pp"][norm_method_key] == "Freeman_Tukey"
                 else X_data
             )
 

--- a/dynamo/tools/metric_velocity.py
+++ b/dynamo/tools/metric_velocity.py
@@ -67,13 +67,13 @@ def cell_wise_confidence(
 
     if ekey == "X":
         X, V = (
-            adata.X if X_data is None else X_data,
+            adata.X if X_data is None else X_data,  ##### Check! inverse_norm for adata.X?
             adata.layers[vkey] if V_data is None else V_data,
         )
-        norm_method = adata.uns["pp"]["norm_method"].copy()
-        adata.uns["pp"]["norm_method"] = "log1p"
+        norm_method = adata.uns["pp"]["layers_norm_method"].copy()
+        adata.uns["pp"]["layers_norm_method"] = "log1p"
         X = inverse_norm(adata, X) if X_data is None else X_data
-        adata.uns["pp"]["norm_method"] = norm_method
+        adata.uns["pp"]["layers_norm_method"] = norm_method
     else:
         X, V = (
             adata.layers[ekey] if X_data is None else X_data,

--- a/dynamo/tools/metric_velocity.py
+++ b/dynamo/tools/metric_velocity.py
@@ -70,10 +70,10 @@ def cell_wise_confidence(
             adata.X if X_data is None else X_data,  ##### Check! inverse_norm for adata.X?
             adata.layers[vkey] if V_data is None else V_data,
         )
-        norm_method = adata.uns["pp"]["layers_norm_method"].copy()
-        adata.uns["pp"]["layers_norm_method"] = "log1p"
+        norm_method = adata.uns["pp"]["X_norm_method"].copy()
+        adata.uns["pp"]["X_norm_method"] = "log1p"
         X = inverse_norm(adata, X) if X_data is None else X_data
-        adata.uns["pp"]["layers_norm_method"] = norm_method
+        adata.uns["pp"]["X_norm_method"] = norm_method
     else:
         X, V = (
             adata.layers[ekey] if X_data is None else X_data,

--- a/dynamo/tools/moments.py
+++ b/dynamo/tools/moments.py
@@ -187,10 +187,12 @@ def moments(
         layer_x = adata.layers[layer].copy()
         matched_x_group_indices = np.where([layer in x for x in [only_splicing, only_labeling, splicing_and_labeling]])
         if len(matched_x_group_indices[0]) == 0:
-            logger.warning(f"layer {layer} is not in any of the {only_splicing, only_labeling, splicing_and_labeling} groups, skipping...")
+            logger.warning(
+                f"layer {layer} is not in any of the {only_splicing, only_labeling, splicing_and_labeling} groups, skipping..."
+            )
             continue
         layer_x_group = matched_x_group_indices[0][0]
-        layer_x = inverse_norm(adata, layer_x)
+        # layer_x = inverse_norm(adata, layer_x)
 
         if mapper[layer] not in adata.layers.keys():
             adata.layers[mapper[layer]], conn = (
@@ -199,9 +201,13 @@ def moments(
                 else (conn.dot(layer_x), conn)
             )
         for layer2 in layers[i:]:
-            matched_y_group_indices = np.where([layer2 in x for x in [only_splicing, only_labeling, splicing_and_labeling]])
+            matched_y_group_indices = np.where(
+                [layer2 in x for x in [only_splicing, only_labeling, splicing_and_labeling]]
+            )
             if len(matched_y_group_indices[0]) == 0:
-                logger.warning(f"layer {layer2} is not in any of the {only_splicing, only_labeling, splicing_and_labeling} groups, skipping...")
+                logger.warning(
+                    f"layer {layer2} is not in any of the {only_splicing, only_labeling, splicing_and_labeling} groups, skipping..."
+                )
                 continue
             layer_y = adata.layers[layer2].copy()
 
@@ -211,7 +217,7 @@ def moments(
             # those calculations are model specific
             if (layer_x_group != layer_y_group) or layer_x_group == 2:
                 continue
-            layer_y = inverse_norm(adata, layer_y)
+            # layer_y = inverse_norm(adata, layer_y)
 
             if mapper[layer2] not in adata.layers.keys():
                 adata.layers[mapper[layer2]], conn = (

--- a/dynamo/tools/moments.py
+++ b/dynamo/tools/moments.py
@@ -192,7 +192,6 @@ def moments(
             )
             continue
         layer_x_group = matched_x_group_indices[0][0]
-        # layer_x = inverse_norm(adata, layer_x)
 
         if mapper[layer] not in adata.layers.keys():
             adata.layers[mapper[layer]], conn = (
@@ -217,7 +216,6 @@ def moments(
             # those calculations are model specific
             if (layer_x_group != layer_y_group) or layer_x_group == 2:
                 continue
-            # layer_y = inverse_norm(adata, layer_y)
 
             if mapper[layer2] not in adata.layers.keys():
                 adata.layers[mapper[layer2]], conn = (
@@ -379,7 +377,7 @@ def prepare_data_deterministic(
     raw = [None] * len(layers)
     for i, layer in enumerate(layers):
         if layer in ["X_total", "total", "M_t"]:
-            if (layer == "X_total" and adata.uns["pp"]["norm_method"] is None) or layer == "M_t":
+            if (layer == "X_total" and adata.uns["pp"]["layers_norm_method"] is None) or layer == "M_t":
                 x_layer = adata[:, genes].layers[layer]
                 if return_ntr:
                     T_genes = adata[:, genes].layers[get_layer_pair(layer)]
@@ -455,7 +453,7 @@ def prepare_data_deterministic(
                     x_layer = x_layer - y_layer
 
         else:
-            if (layer == ["X_new"] and adata.uns["pp"]["norm_method"] is None) or layer == "M_n":
+            if (layer == ["X_new"] and adata.uns["pp"]["layers_norm_method"] is None) or layer == "M_n":
                 total_layer = "X_total" if layer == ["X_new"] else "M_t"
 
                 if return_ntr:

--- a/dynamo/tools/velocyto_scvelo.py
+++ b/dynamo/tools/velocyto_scvelo.py
@@ -124,7 +124,8 @@ def vlm_to_adata(
         "has_protein": False,
         "tkey": None,
         "experiment_type": "conventional",
-        "norm_method": None,
+        "X_norm_method": None,
+        "layers_norm_method": None,
     }
 
     uns["dynamics"] = {


### PR DESCRIPTION
1. Since inverse_norm is only required for the layer X, it is recommended to comment out the function in the moments section. This is because the moments function is designed to run specifically on layers starting with 'X_'.
2. Fix for debug message issue in cell_velocities.