### PR TITLE
Do NOT replace layers spliced/unspliced with pearson residual normalized data

### DIFF
--- a/dynamo/preprocessing/Preprocessor.py
+++ b/dynamo/preprocessing/Preprocessor.py
@@ -671,7 +671,7 @@ class Preprocessor:
         self.select_genes_kwargs = {"n_top_genes": 2000}
         self.normalize_selected_genes = normalize_layers_pearson_residuals
         # select layers in adata to be normalized
-        normalize_layers = DKM.X_LAYER #DKM.get_raw_data_layers(adata)
+        normalize_layers = DKM.X_LAYER
         self.normalize_selected_genes_kwargs = {"layers": normalize_layers, "copy": False}
         self.regress_out_kwargs = update_dict({"obs_keys": []}, self.regress_out_kwargs)
         self.pca_kwargs = {"pca_key": "X_pca", "n_pca_components": 50}

--- a/dynamo/preprocessing/Preprocessor.py
+++ b/dynamo/preprocessing/Preprocessor.py
@@ -671,8 +671,8 @@ class Preprocessor:
         self.select_genes_kwargs = {"n_top_genes": 2000}
         self.normalize_selected_genes = normalize_layers_pearson_residuals
         # select layers in adata to be normalized
-        normalize_layers = DKM.get_raw_data_layers(adata)
-        self.normalize_selected_genes_kwargs = {"layers": normalize_layers, "copy": True}
+        normalize_layers = DKM.X_LAYER #DKM.get_raw_data_layers(adata)
+        self.normalize_selected_genes_kwargs = {"layers": normalize_layers, "copy": False}
         self.regress_out_kwargs = update_dict({"obs_keys": []}, self.regress_out_kwargs)
         self.pca_kwargs = {"pca_key": "X_pca", "n_pca_components": 50}
 
@@ -729,7 +729,7 @@ class Preprocessor:
         self.select_genes = select_genes_by_pearson_residuals
         self.select_genes_kwargs = {"n_top_genes": 2000}
         self.normalize_selected_genes = normalize_layers_pearson_residuals
-        self.normalize_selected_genes_kwargs = {"layers": ["X"], "copy": True}
+        self.normalize_selected_genes_kwargs = {"layers": ["X"], "copy": False}
         self.regress_out_kwargs = update_dict({"obs_keys": []}, self.regress_out_kwargs)
         self.pca_kwargs = {"pca_key": "X_pca", "n_pca_components": 50}
 

--- a/dynamo/preprocessing/Preprocessor.py
+++ b/dynamo/preprocessing/Preprocessor.py
@@ -27,12 +27,10 @@ from .external import (
 from .gene_selection import select_genes_by_seurat_recipe, select_genes_monocle
 from .normalization import calc_sz_factor, normalize
 from .pca import pca
-from .QC import (
-    basic_stats,
-    filter_cells_by_outliers as monocle_filter_cells_by_outliers,
-    filter_genes_by_outliers as monocle_filter_genes_by_outliers,
-    regress_out_parallel,
-)
+from .QC import basic_stats
+from .QC import filter_cells_by_outliers as monocle_filter_cells_by_outliers
+from .QC import filter_genes_by_outliers as monocle_filter_genes_by_outliers
+from .QC import regress_out_parallel
 from .transform import Freeman_Tukey, log, log1p, log2
 from .utils import (
     _infer_labeling_experiment_type,
@@ -674,7 +672,7 @@ class Preprocessor:
         self.normalize_selected_genes = normalize_layers_pearson_residuals
         # select layers in adata to be normalized
         normalize_layers = DKM.get_raw_data_layers(adata)
-        self.normalize_selected_genes_kwargs = {"layers": normalize_layers, "copy": False}
+        self.normalize_selected_genes_kwargs = {"layers": normalize_layers, "copy": True}
         self.regress_out_kwargs = update_dict({"obs_keys": []}, self.regress_out_kwargs)
         self.pca_kwargs = {"pca_key": "X_pca", "n_pca_components": 50}
 
@@ -731,7 +729,7 @@ class Preprocessor:
         self.select_genes = select_genes_by_pearson_residuals
         self.select_genes_kwargs = {"n_top_genes": 2000}
         self.normalize_selected_genes = normalize_layers_pearson_residuals
-        self.normalize_selected_genes_kwargs = {"layers": ["X"], "copy": False}
+        self.normalize_selected_genes_kwargs = {"layers": ["X"], "copy": True}
         self.regress_out_kwargs = update_dict({"obs_keys": []}, self.regress_out_kwargs)
         self.pca_kwargs = {"pca_key": "X_pca", "n_pca_components": 50}
 

--- a/dynamo/preprocessing/external/pearson_residual_recipe.py
+++ b/dynamo/preprocessing/external/pearson_residual_recipe.py
@@ -385,8 +385,10 @@ def _normalize_single_layer_pearson_residuals(
 
     if layer != DKM.X_LAYER:
         main_warning(
-            f"pearson residual should only be used for adata.X and not applied to {layer} layer, "
-            f"so please don't use this residual for velocities and vector field."
+            f"Pearson residual is only recommended for X layer while you are applying on layer: {layer}, "
+            f"This will overwrite existing pearson residual params and create negative values in layers, "
+            f"which will cause error in the velocities calculation. Please run the pearson residual recipe by default "
+            f"if you plan to perform downstream analysis."
         )
         copy = True  # residuals for spliced/unspliced layers will be saved in X_splice/X_unspliced.
 

--- a/dynamo/preprocessing/external/pearson_residual_recipe.py
+++ b/dynamo/preprocessing/external/pearson_residual_recipe.py
@@ -23,11 +23,8 @@ from ...dynamo_logger import (
     main_info_insert_adata_layer,
     main_warning,
 )
+from ...preprocessing.utils import is_nonnegative_integer_arr, seurat_get_mean_var
 from ..QC import filter_genes_by_outliers
-from ...preprocessing.utils import (
-    is_nonnegative_integer_arr,
-    seurat_get_mean_var,
-)
 
 main_logger = LoggerManager.main_logger
 
@@ -235,6 +232,7 @@ def _highly_variable_pearson_residuals(
 
         return df
 
+
 # TODO: Move this function to a higher level. Now this function is called by
 # pearson_residual_recipe, but this function aims to support different recipe in
 # the future.
@@ -281,6 +279,7 @@ def compute_highly_variable_genes(
             check_values=check_values,
             inplace=inplace,
         )
+
 
 def compute_pearson_residuals(
     X: np.ndarray,
@@ -344,6 +343,7 @@ def compute_pearson_residuals(
 
     return residuals
 
+
 # TODO: Read pearson residuals if they exist instead of calculating them again.
 def _normalize_single_layer_pearson_residuals(
     adata: AnnData,
@@ -403,17 +403,14 @@ def _normalize_single_layer_pearson_residuals(
     residuals = compute_pearson_residuals(X, theta, clip, check_values, copy=copy)
     pearson_residual_params_dict = dict(theta=theta, clip=clip, layer=layer)
 
-    if not copy:
-        main_logger.info("replacing layer <%s> with pearson residual normalized data." % (layer))
-        DKM.set_layer_data(adata, layer, residuals, selected_genes_bools)
-        adata.uns["pp"][pp_pearson_store_key] = pearson_residual_params_dict
-    else:
-        results_dict = dict(X=residuals, **pearson_residual_params_dict)
+    DKM.set_layer_data(adata, layer, residuals, selected_genes_bools)
+    adata.uns["pp"][pp_pearson_store_key] = pearson_residual_params_dict
 
     main_logger.finish_progress(progress_name="pearson residual normalization")
 
     if copy:
         return adata
+
 
 def normalize_layers_pearson_residuals(
     adata: AnnData,
@@ -469,6 +466,7 @@ def normalize_layers_pearson_residuals(
         new_X_key = DKM.gen_layer_X_key(layer)
         main_info_insert_adata_layer(new_X_key, indent_level=2)
         adata.layers[new_X_key] = DKM.select_layer_data(temp_adata, layer)
+
 
 # TODO: Combine this function with compute_highly_variable_genes.
 def select_genes_by_pearson_residuals(
@@ -534,6 +532,7 @@ def select_genes_by_pearson_residuals(
         return None
     else:
         return adata, hvg
+
 
 def pearson_residuals(
     adata: AnnData,


### PR DESCRIPTION
#### what does "skipping set X as layer in adata.layers" mean? 
-> Need to check because the current implementation is like below..
```
        if layer == DKM.X_LAYER:
            # TODO: discuss if we need X set in layers
            # X layer will only be used for X_pca
            main_info("skipping set X as layer in adata.layers", indent_level=2)
            continue
```

#### did you replace layers spliced/unspliced with pearson residual normalized data? 
-> This probably a bug... so code is updated to do not replace layers spliced/unsplice.