### PR TITLE
Replace recipe_monocle into Preprocessor for the recipes in tools

### DIFF
--- a/dynamo/preprocessing/Preprocessor.py
+++ b/dynamo/preprocessing/Preprocessor.py
@@ -242,6 +242,10 @@ class Preprocessor:
 
         adata.uns["pp"] = {}
         adata.uns["pp"]["norm_method"] = None
+
+        main_debug("applying convert_gene_name function...")
+        self.convert_gene_name(adata)
+
         self.basic_stats(adata)
         self.add_experiment_info(adata, tkey, experiment_type)
         main_info_insert_adata("tkey=%s" % tkey, "uns['pp']", indent_level=2)
@@ -249,9 +253,6 @@ class Preprocessor:
 
         self.convert_layers2csr(adata)
         self.collapse_species_adata(adata)
-
-        main_debug("applying convert_gene_name function...")
-        self.convert_gene_name(adata)
 
         main_debug("making adata observation index unique after gene name conversion...")
         self.unique_var_obs_adata(adata)

--- a/dynamo/preprocessing/utils.py
+++ b/dynamo/preprocessing/utils.py
@@ -964,3 +964,36 @@ def gen_rotation_2d(degree: float) -> np.ndarray:
         [sin(rad), cos(rad)],
     ]
     return np.array(R)
+
+
+def reset_adata_X(adata: AnnData, experiment_type: str, has_labeling: bool, has_splicing: bool):
+    if has_labeling:
+        if experiment_type.lower() in [
+            "one-shot",
+            "kin",
+            "mixture",
+            "mix_std_stm",
+            "kinetics",
+            "mix_pulse_chase",
+            "mix_kin_deg",
+        ]:
+            adata.X = adata.layers["total"].copy()
+        if experiment_type.lower() in ["deg", "degradation"] and has_splicing:
+            adata.X = adata.layers["spliced"].copy()
+        if experiment_type.lower() in ["deg", "degradation"] and not has_splicing:
+            main_warning(
+                "It is not possible to calculate RNA velocity from a degradation experiment which has no "
+                "splicing information."
+            )
+            adata.X = adata.layers["total"].copy()
+        else:
+            adata.X = adata.layers["total"].copy()
+    else:
+        adata.X = adata.layers["spliced"].copy()
+
+
+def del_raw_layers(adata: AnnData):
+    layers = list(adata.layers.keys())
+    for layer in layers:
+        if not layer.startswith("X_"):
+            del adata.layers[layer]

--- a/dynamo/tools/recipes.py
+++ b/dynamo/tools/recipes.py
@@ -81,7 +81,7 @@ def recipe_kin_data(
         An updated adata object that went through a proper and typical time-resolved RNA velocity analysis.
     """
 
-    from ..preprocessing import Preprocessor, recipe_monocle
+    from ..preprocessing import Preprocessor
 
     keep_filtered_cells = DynamoAdataConfig.use_default_var_if_none(
         keep_filtered_cells, DynamoAdataConfig.RECIPE_KEEP_FILTERED_CELLS_KEY
@@ -272,11 +272,12 @@ def recipe_deg_data(
             "splicing_total_layers": splicing_total_layers,
         }
     )
-    preprocessor.normalize_selected_genes_kwargs.update(
+    preprocessor.normalize_by_cells_function_kwargs.update(
         {
             "X_total_layers": X_total_layers,
             "splicing_total_layers": splicing_total_layers,
             "keep_filtered": keep_filtered_genes,
+            "total_szfactor": "total_Size_Factor",
         }
     )
     preprocessor.filter_cells_by_outliers_kwargs["keep_filtered"] = keep_filtered_cells
@@ -334,12 +335,7 @@ def recipe_deg_data(
             )
 
     else:
-        dynamics(
-            adata,
-            model="deterministic",
-            del_2nd_moments=del_2nd_moments,
-            fraction_for_deg=fraction_for_deg,
-        )
+        dynamics(adata, model="deterministic", del_2nd_moments=del_2nd_moments, fraction_for_deg=fraction_for_deg)
         reduceDimension(adata, reduction_method=basis)
 
     return adata
@@ -444,11 +440,12 @@ def recipe_mix_kin_deg_data(
             "splicing_total_layers": splicing_total_layers,
         }
     )
-    preprocessor.normalize_selected_genes_kwargs.update(
+    preprocessor.normalize_by_cells_function_kwargs.update(
         {
             "X_total_layers": X_total_layers,
             "splicing_total_layers": splicing_total_layers,
             "keep_filtered": keep_filtered_genes,
+            "total_szfactor": "total_Size_Factor",
         }
     )
     preprocessor.filter_cells_by_outliers_kwargs["keep_filtered"] = keep_filtered_cells
@@ -610,11 +607,12 @@ def recipe_one_shot_data(
             "splicing_total_layers": splicing_total_layers,
         }
     )
-    preprocessor.normalize_selected_genes_kwargs.update(
+    preprocessor.normalize_by_cells_function_kwargs.update(
         {
             "X_total_layers": X_total_layers,
             "splicing_total_layers": splicing_total_layers,
             "keep_filtered": keep_filtered_genes,
+            "total_szfactor": "total_Size_Factor",
         }
     )
     preprocessor.filter_cells_by_outliers_kwargs["keep_filtered"] = keep_filtered_cells

--- a/dynamo/tools/recipes.py
+++ b/dynamo/tools/recipes.py
@@ -5,6 +5,11 @@ from anndata import AnnData
 
 from ..configuration import DynamoAdataConfig
 from ..preprocessing.pca import pca
+from ..preprocessing.utils import (
+    del_raw_layers,
+    detect_experiment_datatype,
+    reset_adata_X,
+)
 from .cell_velocities import cell_velocities
 from .connectivity import neighbors, normalize_knn_graph
 from .dimension_reduction import reduceDimension
@@ -76,9 +81,7 @@ def recipe_kin_data(
         An updated adata object that went through a proper and typical time-resolved RNA velocity analysis.
     """
 
-    from ..preprocessing import recipe_monocle
-    from ..preprocessing.pca import pca
-    from ..preprocessing.utils import detect_experiment_datatype
+    from ..preprocessing import Preprocessor
 
     keep_filtered_cells = DynamoAdataConfig.use_default_var_if_none(
         keep_filtered_cells, DynamoAdataConfig.RECIPE_KEEP_FILTERED_CELLS_KEY
@@ -107,23 +110,35 @@ def recipe_kin_data(
             "layers."
         )
 
+    # Preprocessing
+    preprocessor = Preprocessor()
+    preprocessor.config_monocle_recipe(adata, n_top_genes=n_top_genes)
+    preprocessor.size_factor_kwargs.update(
+        {
+            "X_total_layers": X_total_layers,
+            "splicing_total_layers": splicing_total_layers,
+        }
+    )
+    preprocessor.normalize_selected_genes_kwargs.update(
+        {
+            "X_total_layers": X_total_layers,
+            "splicing_total_layers": splicing_total_layers,
+            "keep_filtered": keep_filtered_genes,
+        }
+    )
+    preprocessor.filter_cells_by_outliers_kwargs["keep_filtered"] = keep_filtered_cells
+    preprocessor.select_genes_kwargs["keep_filtered"] = keep_filtered_genes
+
+    if reset_X:
+        reset_adata_X(adata, experiment_type="kin", has_labeling=has_labeling, has_splicing=has_splicing)
+    preprocessor.preprocess_adata_monocle(adata=adata, tkey=tkey, experiment_type="kin")
+    if not keep_raw_layers:
+        del_raw_layers(adata)
+
     if has_splicing and has_labeling:
         # new, total (and uu, ul, su, sl if existed) layers will be normalized with size factor calculated with total
         # layers spliced / unspliced layers will be normalized independently.
-        recipe_monocle(
-            adata,
-            tkey=tkey,
-            experiment_type="kin",
-            reset_X=reset_X,
-            X_total_layers=X_total_layers,
-            splicing_total_layers=splicing_total_layers,
-            n_top_genes=n_top_genes,
-            total_layers=True,
-            keep_filtered_cells=keep_filtered_cells,
-            keep_filtered_genes=keep_filtered_genes,
-            keep_raw_layers=keep_raw_layers,
-            **rm_kwargs,
-        )
+
         tkey = adata.uns["pp"]["tkey"]
         # first calculate moments for labeling data relevant layers using total based connectivity graph
         moments(adata, group=tkey, layers=layers)
@@ -156,20 +171,6 @@ def recipe_kin_data(
         # lastly, project RNA velocity to low dimensional embedding.
         cell_velocities(adata, enforce=True, vkey=vkey, ekey=ekey, basis=basis)
     else:
-        recipe_monocle(
-            adata,
-            tkey=tkey,
-            experiment_type="kin",
-            reset_X=reset_X,
-            X_total_layers=X_total_layers,
-            splicing_total_layers=splicing_total_layers,
-            n_top_genes=n_top_genes,
-            total_layers=True,
-            keep_filtered_cells=keep_filtered_cells,
-            keep_filtered_genes=keep_filtered_genes,
-            keep_raw_layers=keep_raw_layers,
-            **rm_kwargs,
-        )
         dynamics(
             adata,
             model="deterministic",
@@ -246,9 +247,7 @@ def recipe_deg_data(
         An updated adata object that went through a proper and typical time-resolved RNA velocity analysis.
     """
 
-    from ..preprocessing import recipe_monocle
-    from ..preprocessing.pca import pca
-    from ..preprocessing.utils import detect_experiment_datatype
+    from ..preprocessing import Preprocessor
 
     keep_filtered_cells = DynamoAdataConfig.use_default_var_if_none(
         keep_filtered_cells, DynamoAdataConfig.RECIPE_KEEP_FILTERED_CELLS_KEY
@@ -274,24 +273,33 @@ def recipe_deg_data(
             "layers."
         )
 
+    preprocessor = Preprocessor()
+    preprocessor.config_monocle_recipe(adata, n_top_genes=n_top_genes)
+    preprocessor.size_factor_kwargs.update(
+        {
+            "X_total_layers": X_total_layers,
+            "splicing_total_layers": splicing_total_layers,
+        }
+    )
+    preprocessor.normalize_selected_genes_kwargs.update(
+        {
+            "X_total_layers": X_total_layers,
+            "splicing_total_layers": splicing_total_layers,
+            "keep_filtered": keep_filtered_genes,
+        }
+    )
+    preprocessor.filter_cells_by_outliers_kwargs["keep_filtered"] = keep_filtered_cells
+    preprocessor.select_genes_kwargs["keep_filtered"] = keep_filtered_genes
+
+    if reset_X:
+        reset_adata_X(adata, experiment_type="deg", has_labeling=has_labeling, has_splicing=has_splicing)
+    preprocessor.preprocess_adata_monocle(adata=adata, tkey=tkey, experiment_type="deg")
+    if not keep_raw_layers:
+        del_raw_layers(adata)
+
     if has_splicing and has_labeling:
         # new, total (and uu, ul, su, sl if existed) layers will be normalized with size factor calculated with total
         # layers spliced / unspliced layers will be normalized independently.
-        recipe_monocle(
-            adata,
-            tkey=tkey,
-            experiment_type="deg",
-            reset_X=reset_X,
-            X_total_layers=X_total_layers,
-            splicing_total_layers=splicing_total_layers,
-            n_top_genes=n_top_genes,
-            total_layers=True,
-            keep_filtered_cells=keep_filtered_cells,
-            keep_filtered_genes=keep_filtered_genes,
-            keep_raw_layers=keep_raw_layers,
-            **rm_kwargs,
-        )
-
         tkey = adata.uns["pp"]["tkey"]
         # first calculate moments for spliced related layers using spliced based connectivity graph
         moments(adata, layers=["X_spliced", "X_unspliced"])
@@ -335,20 +343,6 @@ def recipe_deg_data(
             )
 
     else:
-        recipe_monocle(
-            adata,
-            tkey=tkey,
-            experiment_type="deg",
-            reset_X=reset_X,
-            X_total_layers=X_total_layers,
-            splicing_total_layers=splicing_total_layers,
-            n_top_genes=n_top_genes,
-            total_layers=True,
-            keep_filtered_cells=keep_filtered_cells,
-            keep_filtered_genes=keep_filtered_genes,
-            keep_raw_layers=keep_raw_layers,
-            **rm_kwargs,
-        )
         dynamics(
             adata,
             model="deterministic",
@@ -421,9 +415,7 @@ def recipe_mix_kin_deg_data(
         An updated adata object that went through a proper and typical time-resolved RNA velocity analysis.
     """
 
-    from ..preprocessing import recipe_monocle
-    from ..preprocessing.pca import pca
-    from ..preprocessing.utils import detect_experiment_datatype
+    from ..preprocessing import Preprocessor
 
     keep_filtered_cells = DynamoAdataConfig.use_default_var_if_none(
         keep_filtered_cells, DynamoAdataConfig.RECIPE_KEEP_FILTERED_CELLS_KEY
@@ -452,23 +444,34 @@ def recipe_mix_kin_deg_data(
             "layers."
         )
 
+    # Preprocessing
+    preprocessor = Preprocessor()
+    preprocessor.config_monocle_recipe(adata, n_top_genes=n_top_genes)
+    preprocessor.size_factor_kwargs.update(
+        {
+            "X_total_layers": X_total_layers,
+            "splicing_total_layers": splicing_total_layers,
+        }
+    )
+    preprocessor.normalize_selected_genes_kwargs.update(
+        {
+            "X_total_layers": X_total_layers,
+            "splicing_total_layers": splicing_total_layers,
+            "keep_filtered": keep_filtered_genes,
+        }
+    )
+    preprocessor.filter_cells_by_outliers_kwargs["keep_filtered"] = keep_filtered_cells
+    preprocessor.select_genes_kwargs["keep_filtered"] = keep_filtered_genes
+
+    if reset_X:
+        reset_adata_X(adata, experiment_type="mix_pulse_chase", has_labeling=has_labeling, has_splicing=has_splicing)
+    preprocessor.preprocess_adata_monocle(adata=adata, tkey=tkey, experiment_type="mix_pulse_chase")
+    if not keep_raw_layers:
+        del_raw_layers(adata)
+
     if has_splicing and has_labeling:
         # new, total (and uu, ul, su, sl if existed) layers will be normalized with size factor calculated with total
         # layers spliced / unspliced layers will be normalized independently.
-        recipe_monocle(
-            adata,
-            tkey=tkey,
-            experiment_type="mix_pulse_chase",
-            reset_X=reset_X,
-            X_total_layers=X_total_layers,
-            splicing_total_layers=splicing_total_layers,
-            n_top_genes=n_top_genes,
-            total_layers=True,
-            keep_filtered_cells=keep_filtered_cells,
-            keep_filtered_genes=keep_filtered_genes,
-            keep_raw_layers=keep_raw_layers,
-            **rm_kwargs,
-        )
         tkey = adata.uns["pp"]["tkey"]
         # first calculate moments for labeling data relevant layers using total based connectivity graph
         moments(adata, group=tkey, layers=layers)
@@ -501,20 +504,6 @@ def recipe_mix_kin_deg_data(
         # lastly, project RNA velocity to low dimensional embedding.
         cell_velocities(adata, enforce=True, vkey=vkey, ekey=ekey, basis=basis)
     else:
-        recipe_monocle(
-            adata,
-            tkey=tkey,
-            experiment_type="mix_pulse_chase",
-            reset_X=reset_X,
-            X_total_layers=X_total_layers,
-            splicing_total_layers=splicing_total_layers,
-            n_top_genes=n_top_genes,
-            total_layers=True,
-            keep_filtered_cells=keep_filtered_cells,
-            keep_filtered_genes=keep_filtered_genes,
-            keep_raw_layers=keep_raw_layers,
-            **rm_kwargs,
-        )
         dynamics(
             adata,
             model="deterministic",
@@ -592,9 +581,7 @@ def recipe_one_shot_data(
         An updated adata object that went through a proper and typical time-resolved RNA velocity analysis.
     """
 
-    from ..preprocessing import recipe_monocle
-    from ..preprocessing.pca import pca
-    from ..preprocessing.utils import detect_experiment_datatype
+    from ..preprocessing import Preprocessor
 
     keep_filtered_cells = DynamoAdataConfig.use_default_var_if_none(
         keep_filtered_cells, DynamoAdataConfig.RECIPE_KEEP_FILTERED_CELLS_KEY
@@ -623,23 +610,34 @@ def recipe_one_shot_data(
             "layers."
         )
 
+    # Preprocessing
+    preprocessor = Preprocessor()
+    preprocessor.config_monocle_recipe(adata, n_top_genes=n_top_genes)
+    preprocessor.size_factor_kwargs.update(
+        {
+            "X_total_layers": X_total_layers,
+            "splicing_total_layers": splicing_total_layers,
+        }
+    )
+    preprocessor.normalize_selected_genes_kwargs.update(
+        {
+            "X_total_layers": X_total_layers,
+            "splicing_total_layers": splicing_total_layers,
+            "keep_filtered": keep_filtered_genes,
+        }
+    )
+    preprocessor.filter_cells_by_outliers_kwargs["keep_filtered"] = keep_filtered_cells
+    preprocessor.select_genes_kwargs["keep_filtered"] = keep_filtered_genes
+
+    if reset_X:
+        reset_adata_X(adata, experiment_type="one-shot", has_labeling=has_labeling, has_splicing=has_splicing)
+    preprocessor.preprocess_adata_monocle(adata=adata, tkey=tkey, experiment_type="one-shot")
+    if not keep_raw_layers:
+        del_raw_layers(adata)
+
     if has_splicing and has_labeling:
         # new, total (and uu, ul, su, sl if existed) layers will be normalized with size factor calculated with total
         # layers spliced / unspliced layers will be normalized independently.
-        recipe_monocle(
-            adata,
-            tkey=tkey,
-            experiment_type="one-shot",
-            reset_X=reset_X,
-            X_total_layers=X_total_layers,
-            splicing_total_layers=splicing_total_layers,
-            n_top_genes=n_top_genes,
-            total_layers=True,
-            keep_filtered_cells=keep_filtered_cells,
-            keep_filtered_genes=keep_filtered_genes,
-            keep_raw_layers=keep_raw_layers,
-            **rm_kwargs,
-        )
         tkey = adata.uns["pp"]["tkey"]
         # first calculate moments for labeling data relevant layers using total based connectivity graph
         moments(adata, group=tkey, layers=layers)
@@ -672,20 +670,6 @@ def recipe_one_shot_data(
         # lastly, project RNA velocity to low dimensional embedding.
         cell_velocities(adata, enforce=True, vkey=vkey, ekey=ekey, basis=basis)
     else:
-        recipe_monocle(
-            adata,
-            tkey=tkey,
-            experiment_type="one-shot",
-            reset_X=reset_X,
-            X_total_layers=X_total_layers,
-            splicing_total_layers=splicing_total_layers,
-            n_top_genes=n_top_genes,
-            total_layers=True,
-            keep_filtered_cells=keep_filtered_cells,
-            keep_filtered_genes=keep_filtered_genes,
-            keep_raw_layers=keep_raw_layers,
-            **rm_kwargs,
-        )
         dynamics(
             adata,
             model="deterministic",


### PR DESCRIPTION
1. Replace recipe_monocle into Preprocessor for the recipes in tools.
2. convert_gene_name should be called first than basic_stats, due to it has the inplace option for valid genes.