### PR TITLE
remove cdlib dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,6 @@ seaborn>=0.9.0
 colorcet>=2.0.1
 tqdm
 python-igraph>=0.7.1
-cdlib>=0.2.6
 louvain==0.8.0
 pynndescent>=0.5.2
 pre-commit


### PR DESCRIPTION
Since we import cdlib by:
```
try:
        import cdlib as algorithms
except ImportError:
        raise ImportError("Please install cdlib via `pip install cdlib` for clustering on graph.")
```
It would be better to remove it from the requirements.