### PR TITLE
Bump version: 1.3.0 → 1.3.1

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -84,7 +84,7 @@ copyright = "2020, Xiaojie Qiu, Yan Zhang, Ke Ni"
 author = "Xiaojie Qiu, Yan Zhang, Ke Ni"
 
 # The full version, including alpha/beta/rc tags
-release = "1.3.0"
+release = "1.3.1"
 
 # -- General configuration ---------------------------------------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.3.0
+current_version = 1.3.1
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open("README.md", "r") as fh:
 if __name__ == "__main__":
     setup(
         name="dynamo-release",
-        version="v1.3.0",
+        version="v1.3.1",
         python_requires=">=3.7",
         install_requires=read_requirements("requirements.txt"),
         extras_require={


### PR DESCRIPTION
Update a new patch for Dynamo ver 1.3

- Remove cdlib and KDEpy from the requirement.
- Add the sampling number n to the parameters of the topography plotting function.