### PR TITLE
Debug kinetic_heatmap

### DIFF
--- a/dynamo/plot/time_series.py
+++ b/dynamo/plot/time_series.py
@@ -209,7 +209,7 @@ def kinetic_heatmap(
     color_map: int = "BrBG",
     gene_order_method: Literal["maximum", "half_max_ordering", "raw"] = "maximum",
     show_colorbar: bool = False,
-    cluster_row_col: Tuple[bool, bool] = (False, False),
+    cluster_row_col: List[bool] = [False, False],
     figsize: Tuple[float, float] = (11.5, 6),
     standard_scale: int = 1,
     n_convolve: int = 30,


### PR DESCRIPTION
Fixed the second issue described [here](https://github.com/aristoteleo/dynamo-release/issues/553) that the heatmap can't be transposed caused by wrong initialization.