### PR TITLE
Save velocity parameters to .varm instead .var

### DIFF
--- a/dynamo/plot/dynamics.py
+++ b/dynamo/plot/dynamics.py
@@ -1326,7 +1326,7 @@ def dynamics(
 
         true_p = None
         true_params = [None, None, None]
-        vel_params_df = get_vel_params(adata).loc[valid_gene_names]
+        vel_params_df = get_vel_params(valid_adata)
         logLL = vel_params_df.loc[valid_gene_names, prefix + "logLL"]
         est_params_df = vel_params_df.loc[
             valid_gene_names,

--- a/dynamo/plot/dynamics.py
+++ b/dynamo/plot/dynamics.py
@@ -1212,7 +1212,7 @@ def dynamics(
         main_warning(
             "dynamics plot doesn't support conventional experiment type, using phase_portraits function instead."
         )
-        phase_portraits(adata)
+        phase_portraits(adata, genes=genes, save_show_or_return=save_show_or_return)
 
     T_uniq = np.unique(T)
     t = np.linspace(0, T_uniq[-1], 1000)

--- a/dynamo/plot/scatters.py
+++ b/dynamo/plot/scatters.py
@@ -23,7 +23,7 @@ from ..docrep import DocstringProcessor
 from ..dynamo_logger import main_debug, main_info, main_warning
 from ..preprocessing.utils import affine_transform, gen_rotation_2d
 from ..tools.moments import calc_1nd_moment
-from ..tools.utils import flatten, get_mapper, update_dict
+from ..tools.utils import flatten, get_mapper, get_vel_params, update_dict, update_vel_params
 from .utils import (
     _datashade_points,
     _get_adata_color_vec,
@@ -808,9 +808,11 @@ def scatters(
                         points.iloc[:, 0].max() * 0.80,
                     )
                     k_name = "gamma_k" if _adata.uns["dynamics"]["experiment_type"] == "one-shot" else "gamma"
-                    if k_name in _adata.var.columns:
-                        if not ("gamma_b" in _adata.var.columns) or all(_adata.var.gamma_b.isna()):
-                            _adata.var.loc[:, "gamma_b"] = 0
+                    vel_params_df = get_vel_params(_adata)
+                    if k_name in vel_params_df.columns:
+                        if not ("gamma_b" in vel_params_df.columns) or all(vel_params_df.gamma_b.isna()):
+                            vel_params_df.loc[:, "gamma_b"] = 0
+                            update_vel_params(_adata, params_df=vel_params_df)
                         ax.plot(
                             xnew,
                             xnew * _adata[:, cur_b].var.loc[:, k_name].unique()
@@ -841,9 +843,11 @@ def scatters(
                             + group_adata[:, cur_b].var.loc[:, group_b_key].unique()
                         )
                         ax.annotate(group + "_" + cur_group, xy=(group_xnew[-1], group_ynew[-1]))
-                        if group_k_name in group_adata.var.columns:
-                            if not (group_b_key in group_adata.var.columns) or all(group_adata.var[group_b_key].isna()):
-                                group_adata.var.loc[:, group_b_key] = 0
+                        vel_params_df = get_vel_params(group_adata)
+                        if group_k_name in vel_params_df.columns:
+                            if not (group_b_key in vel_params_df.columns) or all(vel_params_df[group_b_key].isna()):
+                                vel_params_df.loc[:, group_b_key] = 0
+                                update_vel_params(group_adata, params_df=vel_params_df)
                                 main_info("No %s found, setting all bias terms to zero" % group_b_key)
                             ax.plot(
                                 group_xnew,

--- a/dynamo/plot/utils_dynamics.py
+++ b/dynamo/plot/utils_dynamics.py
@@ -9,7 +9,7 @@ from ..tools.moments import (
     prepare_data_mix_no_splicing,
     prepare_data_no_splicing,
 )
-from ..tools.utils import get_mapper
+from ..tools.utils import get_mapper, get_vel_params
 from .utils import _to_hex
 
 
@@ -1685,8 +1685,9 @@ def plot_kin_twostep(
 
     colors = pd.Series(T).map(new_color_key).values
 
-    r2 = adata[:, genes].var["gamma_r2"]
-    mean_R2 = adata[:, genes].var["mean_R2"]
+    vel_params_df = get_vel_params(adata)
+    r2 = vel_params_df.loc[genes, "gamma_r2"]
+    mean_R2 = vel_params_df.loc[genes, "mean_R2"]
 
     for i, gene_name in enumerate(genes):
         cur_X_data, cur_X_fit_data, cur_logLL = (

--- a/dynamo/prediction/tscRNA_seq.py
+++ b/dynamo/prediction/tscRNA_seq.py
@@ -4,6 +4,7 @@ import anndata
 from scipy.sparse import csr_matrix
 
 from ..dynamo_logger import LoggerManager, main_exception, main_warning
+from ..tools.utils import get_vel_params
 from ..utils import copy_adata
 from .utils import init_r0_pulse
 
@@ -67,7 +68,7 @@ def get_pulse_r0(
         % (tkey, nkey, gamma_k_key)
     )
     R, L = adata[:, gene_names].layers[tkey], adata[:, gene_names].layers[nkey]
-    K = adata[:, gene_names].var[gamma_k_key].values.astype(float)
+    K = get_vel_params(adata, params=gamma_k_key, genes=gene_names).astype(float)
 
     logger.info("Calculate initial total RNA via r0 = (r - l) / (1 - k)")
     res = init_r0_pulse(R, L, K[None, :])

--- a/dynamo/tools/__init__.py
+++ b/dynamo/tools/__init__.py
@@ -93,6 +93,7 @@ from .utils import (
     AnnDataPredicate,
     cell_norm,
     compute_smallest_distance,
+    get_vel_params,
     index_gene,
     select,
     select_cell,

--- a/dynamo/tools/dynamics.py
+++ b/dynamo/tools/dynamics.py
@@ -41,6 +41,7 @@ from .utils import (
     get_data_for_kin_params_estimation,
     get_U_S_for_velocity_estimation,
     get_valid_bools,
+    get_vel_params,
     one_shot_alpha_matrix,
     remove_2nd_moments,
     set_param_kinetic,
@@ -479,8 +480,9 @@ def dynamics(
                 est_method = "gmm" if model.lower() == "stochastic" else "ols"
 
             if experiment_type.lower() == "one-shot":
-                beta = subset_adata.var.beta if "beta" in subset_adata.var.keys() else None
-                gamma = subset_adata.var.gamma if "gamma" in subset_adata.var.keys() else None
+                vel_params_df = get_vel_params(subset_adata)
+                beta = vel_params_df.beta if "beta" in vel_params_df.columns else None
+                gamma = vel_params_df.gamma if "gamma" in vel_params_df.columns else None
                 ss_estimation_kwargs = {"beta": beta, "gamma": gamma}
             else:
                 ss_estimation_kwargs = {}

--- a/dynamo/tools/dynamics.py
+++ b/dynamo/tools/dynamics.py
@@ -480,9 +480,12 @@ def dynamics(
                 est_method = "gmm" if model.lower() == "stochastic" else "ols"
 
             if experiment_type.lower() == "one-shot":
-                vel_params_df = get_vel_params(subset_adata)
-                beta = vel_params_df.beta if "beta" in vel_params_df.columns else None
-                gamma = vel_params_df.gamma if "gamma" in vel_params_df.columns else None
+                try:
+                    vel_params_df = get_vel_params(subset_adata)
+                    beta = vel_params_df.beta if "beta" in vel_params_df.columns else None
+                    gamma = vel_params_df.gamma if "gamma" in vel_params_df.columns else None
+                except KeyError:
+                    beta, gamma = None, None
                 ss_estimation_kwargs = {"beta": beta, "gamma": gamma}
             else:
                 ss_estimation_kwargs = {}

--- a/dynamo/tools/pseudotime_velocity.py
+++ b/dynamo/tools/pseudotime_velocity.py
@@ -235,5 +235,5 @@ def pseudotime_velocity(
 
         logger.info("set gamma to be 0 in .var. so that velocity_S = unspliced RNA.")
         logger.info_insert_adata("gamma", "var", indent_level=2)
-        adata.var["gamma"] = 0
-        adata.var["gamma_b"] = 0
+        adata.varm["vel_params"] = np.zeros((adata.n_vars, 2))
+        adata.uns["vel_params_names"] = ["gamma", "gamma_b"]

--- a/dynamo/tools/pseudotime_velocity.py
+++ b/dynamo/tools/pseudotime_velocity.py
@@ -235,5 +235,5 @@ def pseudotime_velocity(
 
         logger.info("set gamma to be 0 in .var. so that velocity_S = unspliced RNA.")
         logger.info_insert_adata("gamma", "var", indent_level=2)
-        adata.varm["vel_params"] = np.zeros((adata.n_vars, 2))
-        adata.uns["vel_params_names"] = ["gamma", "gamma_b"]
+        adata.varm["pseudotime_vel_params"] = np.zeros((adata.n_vars, 2))
+        adata.uns["pseudotime_vel_params_names"] = ["gamma", "gamma_b"]

--- a/dynamo/tools/utils.py
+++ b/dynamo/tools/utils.py
@@ -1630,7 +1630,7 @@ def get_vel_params(
         adata: the anndata object which contains the parameters.
         params: the names of parameters to query. If set to None, the entire velocity parameters DataFrame from `.varm`
             will be returned.
-        kin_param_pre: the prefix used in dynamics when estimating the parameters.
+        kin_param_pre: the prefix used to kinetic parameters related to RNA dynamics.
         skip_cell_wise: whether to skip the detected cell wise parameters. If set to True, the mean will be returned
             instead of cell wise parameters.
 
@@ -1641,7 +1641,7 @@ def get_vel_params(
         params = [params]
 
     if kin_param_pre + "vel_params" not in adata.varm.keys():
-        raise KeyError("No velocity parameters found.")
+        raise KeyError("The key of velocity related parameters are not found in varm.")
 
     array_data = adata.varm[kin_param_pre + "vel_params"]
     df_columns = adata.uns[kin_param_pre + "vel_params_names"]
@@ -1673,15 +1673,15 @@ def get_vel_params(
 
 
 def update_vel_params(adata: AnnData, params_df: pd.DataFrame, kin_param_pre: str = "") -> None:
-    """Update the velocity parameters.
+    """Update the kinetic parameters related to RNA velocity calculation.
 
     Args:
-        adata: the AnnData obejct to update.
-        params_df: the new velocity parameters.
-        kin_param_pre: the prefix to locate the corresponding parameters.
+        adata: the AnnData object whose kinetic parameters related to RNA velocity calculation will be updated.
+        params_df: the dataframe of kinetic parameters related to RNA velocity calculation.
+        kin_param_pre: the prefix used to kinetic parameters related to RNA dynamics.
 
     Returns:
-        The anndata object will be updated.
+        The anndata object will be updated with parameters and columns names from given dataframe.
     """
     adata.varm[kin_param_pre + "vel_params"] = params_df.to_numpy()
     adata.uns[kin_param_pre + "vel_params_names"] = list(params_df.columns)

--- a/dynamo/tools/utils.py
+++ b/dynamo/tools/utils.py
@@ -1544,7 +1544,8 @@ def set_param_ss(
             params_df.loc[valid_ind, kin_param_pre + "delta_r2"][ind_for_proteins] = delta_r2
             params_df.loc[valid_ind, kin_param_pre + "p_half_life"][ind_for_proteins] = np.log(2) / delta
 
-    adata.uns[kin_param_pre + "params"] = params_df
+    adata.varm[kin_param_pre + "vel_params"] = params_df.to_numpy()
+    adata.uns[kin_param_pre + "vel_params_names"] = list(params_df.columns)
 
     return adata
 
@@ -1608,7 +1609,8 @@ def set_param_kinetic(
     extra_params.columns = [kin_param_pre + i for i in extra_params.columns]
     extra_params = extra_params.set_index(adata.var.index[valid_ind])
     var = pd.concat((params_df, extra_params), axis=1, sort=False)
-    adata.uns[kin_param_pre + "params"] = var
+    adata.varm[kin_param_pre + "vel_params"] = var.to_numpy()
+    adata.uns[kin_param_pre + "vel_params_names"] = list(var.columns)
 
     return adata
 

--- a/dynamo/tools/utils.py
+++ b/dynamo/tools/utils.py
@@ -1620,7 +1620,8 @@ def get_vel_params(
     params: Union[List, str],
     kin_param_pre: str = "",
     skip_cell_wise: bool = False,
-) -> Tuple:
+    return_all: bool = False,
+) -> Union[Tuple, pd.DataFrame]:
     """Get the velocity parameters based on input names.
 
     Args:
@@ -1641,8 +1642,11 @@ def get_vel_params(
 
     array_data = adata.varm[kin_param_pre + "vel_params"]
     df_columns = adata.uns[kin_param_pre + "vel_params_names"]
-    df = pd.DataFrame(array_data, columns=df_columns)
+    df = pd.DataFrame(array_data, index=adata.var_names, columns=df_columns)
     target_params = []
+
+    if return_all:
+        return df
 
     for param in params:
         if param == "alpha":

--- a/dynamo/tools/utils.py
+++ b/dynamo/tools/utils.py
@@ -1567,23 +1567,24 @@ def set_param_kinetic(
     cur_cells_bools,
     valid_ind,
 ):
+    params_df = pd.DataFrame(index=adata.var.index)
     if cur_grp == _group[0]:
         (
-            adata.var[kin_param_pre + "alpha"],
-            adata.var[kin_param_pre + "a"],
-            adata.var[kin_param_pre + "b"],
-            adata.var[kin_param_pre + "alpha_a"],
-            adata.var[kin_param_pre + "alpha_i"],
-            adata.var[kin_param_pre + "beta"],
-            adata.var[kin_param_pre + "p_half_life"],
-            adata.var[kin_param_pre + "gamma"],
-            adata.var[kin_param_pre + "half_life"],
-            adata.var[kin_param_pre + "cost"],
-            adata.var[kin_param_pre + "logLL"],
+            params_df[kin_param_pre + "alpha"],
+            params_df[kin_param_pre + "a"],
+            params_df[kin_param_pre + "b"],
+            params_df[kin_param_pre + "alpha_a"],
+            params_df[kin_param_pre + "alpha_i"],
+            params_df[kin_param_pre + "beta"],
+            params_df[kin_param_pre + "p_half_life"],
+            params_df[kin_param_pre + "gamma"],
+            params_df[kin_param_pre + "half_life"],
+            params_df[kin_param_pre + "cost"],
+            params_df[kin_param_pre + "logLL"],
         ) = (None, None, None, None, None, None, None, None, None, None, None)
 
     if isarray(alpha) and alpha.ndim > 1:
-        adata.var.loc[valid_ind, kin_param_pre + "alpha"] = alpha.mean(1)
+        params_df.loc[valid_ind, kin_param_pre + "alpha"] = alpha.mean(1)
         cur_cells_ind, valid_ind_ = (
             np.where(cur_cells_bools)[0][:, np.newaxis],
             np.where(valid_ind)[0],
@@ -1593,21 +1594,21 @@ def set_param_kinetic(
         alpha = alpha.T.tocsr() if sp.issparse(alpha) else sp.csr_matrix(alpha, dtype=np.float64).T
         adata.layers["cell_wise_alpha"][cur_cells_ind, valid_ind_] = alpha
     else:
-        adata.var.loc[valid_ind, kin_param_pre + "alpha"] = alpha
-    adata.var.loc[valid_ind, kin_param_pre + "a"] = a
-    adata.var.loc[valid_ind, kin_param_pre + "b"] = b
-    adata.var.loc[valid_ind, kin_param_pre + "alpha_a"] = alpha_a
-    adata.var.loc[valid_ind, kin_param_pre + "alpha_i"] = alpha_i
-    adata.var.loc[valid_ind, kin_param_pre + "beta"] = beta
-    adata.var.loc[valid_ind, kin_param_pre + "gamma"] = gamma
-    adata.var.loc[valid_ind, kin_param_pre + "half_life"] = np.log(2) / gamma
-    adata.var.loc[valid_ind, kin_param_pre + "cost"] = cost
-    adata.var.loc[valid_ind, kin_param_pre + "logLL"] = logLL
+        params_df.loc[valid_ind, kin_param_pre + "alpha"] = alpha
+    params_df.loc[valid_ind, kin_param_pre + "a"] = a
+    params_df.loc[valid_ind, kin_param_pre + "b"] = b
+    params_df.loc[valid_ind, kin_param_pre + "alpha_a"] = alpha_a
+    params_df.loc[valid_ind, kin_param_pre + "alpha_i"] = alpha_i
+    params_df.loc[valid_ind, kin_param_pre + "beta"] = beta
+    params_df.loc[valid_ind, kin_param_pre + "gamma"] = gamma
+    params_df.loc[valid_ind, kin_param_pre + "half_life"] = np.log(2) / gamma
+    params_df.loc[valid_ind, kin_param_pre + "cost"] = cost
+    params_df.loc[valid_ind, kin_param_pre + "logLL"] = logLL
     # add extra parameters (u0, uu0, etc.)
     extra_params.columns = [kin_param_pre + i for i in extra_params.columns]
     extra_params = extra_params.set_index(adata.var.index[valid_ind])
-    var = pd.concat((adata.var, extra_params), axis=1, sort=False)
-    adata.var = var
+    var = pd.concat((params_df, extra_params), axis=1, sort=False)
+    adata.uns[kin_param_pre + "params"] = var
 
     return adata
 

--- a/dynamo/tools/utils.py
+++ b/dynamo/tools/utils.py
@@ -1617,10 +1617,9 @@ def set_param_kinetic(
 
 def get_vel_params(
     adata: AnnData,
-    params: Union[List, str],
+    params: Optional[Union[List, str]] = None,
     kin_param_pre: str = "",
     skip_cell_wise: bool = False,
-    return_all: bool = False,
 ) -> Union[Tuple, pd.DataFrame]:
     """Get the velocity parameters based on input names.
 
@@ -1645,7 +1644,7 @@ def get_vel_params(
     df = pd.DataFrame(array_data, index=adata.var_names, columns=df_columns)
     target_params = []
 
-    if return_all:
+    if params is None:
         return df
 
     for param in params:

--- a/dynamo/tools/utils.py
+++ b/dynamo/tools/utils.py
@@ -1615,6 +1615,38 @@ def set_param_kinetic(
     return adata
 
 
+def get_vel_params(
+    adata: AnnData,
+    params: Union[List, str],
+    kin_param_pre: str = "",
+    skip_cell_wise: bool = False,
+) -> Tuple:
+    if type(params) is str:
+        params = [params]
+
+    if kin_param_pre + "vel_params" not in adata.varm.keys():
+        raise KeyError("No velocity parameters found.")
+
+    array_data = adata.varm[kin_param_pre + "vel_params"]
+    df_columns = adata.uns[kin_param_pre + "vel_params_names"]
+    df = pd.DataFrame(array_data, columns=df_columns)
+    target_params = []
+
+    for param in params:
+        if param == "alpha":
+            if not skip_cell_wise:
+                if "cell_wise_alpha" in adata.layers.keys():
+                    target_params.append(adata.layers["cell_wise_alpha"])
+                elif "alpha" in adata.varm.keys():
+                    target_params.append(adata.varm[kin_param_pre + "alpha"])
+                else:
+                    target_params.append(df[kin_param_pre + "alpha"].values)
+                continue
+        target_params.append(df[kin_param_pre + param].values)
+
+    return tuple(target_params)
+
+
 def get_U_S_for_velocity_estimation(subset_adata, use_moments, has_splicing, has_labeling, log_unnormalized, NTR):
     mapper = get_mapper()
 

--- a/dynamo/tools/utils.py
+++ b/dynamo/tools/utils.py
@@ -1627,7 +1627,8 @@ def get_vel_params(
 
     Args:
         adata: the anndata object which contains the parameters.
-        params: the names of parameters to query,
+        params: the names of parameters to query. If set to None, the entire velocity parameters DataFrame from `.varm`
+            will be returned.
         kin_param_pre: the prefix used in dynamics when estimating the parameters.
         skip_cell_wise: whether to skip the detected cell wise parameters. If set to True, the mean will be returned
             instead of cell wise parameters.

--- a/dynamo/tools/utils.py
+++ b/dynamo/tools/utils.py
@@ -1392,30 +1392,31 @@ def set_param_ss(
     valid_ind,
     ind_for_proteins,
 ):
+    params_df = pd.DataFrame(index=adata.var.index)
     if experiment_type == "mix_std_stm":
         if alpha is not None:
             if cur_grp == _group[0]:
                 adata.varm[kin_param_pre + "alpha"] = np.zeros((adata.shape[1], alpha[1].shape[1]))
             adata.varm[kin_param_pre + "alpha"][valid_ind, :] = alpha[1]
             (
-                adata.var[kin_param_pre + "alpha"],
-                adata.var[kin_param_pre + "alpha_std"],
+                params_df[kin_param_pre + "alpha"],
+                params_df[kin_param_pre + "alpha_std"],
             ) = (None, None)
             (
-                adata.var.loc[valid_ind, kin_param_pre + "alpha"],
-                adata.var.loc[valid_ind, kin_param_pre + "alpha_std"],
+                params_df.loc[valid_ind, kin_param_pre + "alpha"],
+                params_df.loc[valid_ind, kin_param_pre + "alpha_std"],
             ) = (alpha[1][:, -1], alpha[0])
 
         if cur_grp == _group[0]:
             (
-                adata.var[kin_param_pre + "beta"],
-                adata.var[kin_param_pre + "gamma"],
-                adata.var[kin_param_pre + "half_life"],
+                params_df[kin_param_pre + "beta"],
+                params_df[kin_param_pre + "gamma"],
+                params_df[kin_param_pre + "half_life"],
             ) = (None, None, None)
 
-        adata.var.loc[valid_ind, kin_param_pre + "beta"] = beta
-        adata.var.loc[valid_ind, kin_param_pre + "gamma"] = gamma
-        adata.var.loc[valid_ind, kin_param_pre + "half_life"] = np.log(2) / gamma
+        params_df.loc[valid_ind, kin_param_pre + "beta"] = beta
+        params_df.loc[valid_ind, kin_param_pre + "gamma"] = gamma
+        params_df.loc[valid_ind, kin_param_pre + "half_life"] = np.log(2) / gamma
     else:
         if alpha is not None:
             if len(alpha.shape) > 1:  # for each cell
@@ -1426,21 +1427,21 @@ def set_param_ss(
                         else np.zeros(adata.shape[::-1])
                     )  #
                 adata.varm[kin_param_pre + "alpha"][valid_ind, :] = alpha  #
-                adata.var.loc[valid_ind, kin_param_pre + "alpha"] = alpha.mean(1)
+                params_df.loc[valid_ind, kin_param_pre + "alpha"] = alpha.mean(1)
             elif len(alpha.shape) == 1:
                 if cur_grp == _group[0]:
-                    adata.var[kin_param_pre + "alpha"] = None
-                adata.var.loc[valid_ind, kin_param_pre + "alpha"] = alpha
+                    params_df[kin_param_pre + "alpha"] = None
+                params_df.loc[valid_ind, kin_param_pre + "alpha"] = alpha
 
         if cur_grp == _group[0]:
             (
-                adata.var[kin_param_pre + "beta"],
-                adata.var[kin_param_pre + "gamma"],
-                adata.var[kin_param_pre + "half_life"],
+                params_df[kin_param_pre + "beta"],
+                params_df[kin_param_pre + "gamma"],
+                params_df[kin_param_pre + "half_life"],
             ) = (None, None, None)
-        adata.var.loc[valid_ind, kin_param_pre + "beta"] = beta
-        adata.var.loc[valid_ind, kin_param_pre + "gamma"] = gamma
-        adata.var.loc[valid_ind, kin_param_pre + "half_life"] = None if gamma is None else np.log(2) / gamma
+        params_df.loc[valid_ind, kin_param_pre + "beta"] = beta
+        params_df.loc[valid_ind, kin_param_pre + "gamma"] = gamma
+        params_df.loc[valid_ind, kin_param_pre + "half_life"] = None if gamma is None else np.log(2) / gamma
 
         (
             alpha_intercept,
@@ -1466,22 +1467,22 @@ def set_param_ss(
             alpha_r2[~np.isfinite(alpha_r2)] = 0
         if cur_grp == _group[0]:
             (
-                adata.var[kin_param_pre + "alpha_b"],
-                adata.var[kin_param_pre + "alpha_r2"],
-                adata.var[kin_param_pre + "gamma_b"],
-                adata.var[kin_param_pre + "gamma_r2"],
-                adata.var[kin_param_pre + "gamma_logLL"],
-                adata.var[kin_param_pre + "delta_b"],
-                adata.var[kin_param_pre + "delta_r2"],
-                adata.var[kin_param_pre + "bs"],
-                adata.var[kin_param_pre + "bf"],
-                adata.var[kin_param_pre + "uu0"],
-                adata.var[kin_param_pre + "ul0"],
-                adata.var[kin_param_pre + "su0"],
-                adata.var[kin_param_pre + "sl0"],
-                adata.var[kin_param_pre + "U0"],
-                adata.var[kin_param_pre + "S0"],
-                adata.var[kin_param_pre + "total0"],
+                params_df[kin_param_pre + "alpha_b"],
+                params_df[kin_param_pre + "alpha_r2"],
+                params_df[kin_param_pre + "gamma_b"],
+                params_df[kin_param_pre + "gamma_r2"],
+                params_df[kin_param_pre + "gamma_logLL"],
+                params_df[kin_param_pre + "delta_b"],
+                params_df[kin_param_pre + "delta_r2"],
+                params_df[kin_param_pre + "bs"],
+                params_df[kin_param_pre + "bf"],
+                params_df[kin_param_pre + "uu0"],
+                params_df[kin_param_pre + "ul0"],
+                params_df[kin_param_pre + "su0"],
+                params_df[kin_param_pre + "sl0"],
+                params_df[kin_param_pre + "U0"],
+                params_df[kin_param_pre + "S0"],
+                params_df[kin_param_pre + "total0"],
             ) = (
                 None,
                 None,
@@ -1501,47 +1502,49 @@ def set_param_ss(
                 None,
             )
 
-        adata.var.loc[valid_ind, kin_param_pre + "alpha_b"] = alpha_intercept
-        adata.var.loc[valid_ind, kin_param_pre + "alpha_r2"] = alpha_r2
+        params_df.loc[valid_ind, kin_param_pre + "alpha_b"] = alpha_intercept
+        params_df.loc[valid_ind, kin_param_pre + "alpha_r2"] = alpha_r2
 
         if gamma_r2 is not None:
             gamma_r2[~np.isfinite(gamma_r2)] = 0
-        adata.var.loc[valid_ind, kin_param_pre + "gamma_b"] = gamma_intercept
-        adata.var.loc[valid_ind, kin_param_pre + "gamma_r2"] = gamma_r2
-        adata.var.loc[valid_ind, kin_param_pre + "gamma_logLL"] = gamma_logLL
+        params_df.loc[valid_ind, kin_param_pre + "gamma_b"] = gamma_intercept
+        params_df.loc[valid_ind, kin_param_pre + "gamma_r2"] = gamma_r2
+        params_df.loc[valid_ind, kin_param_pre + "gamma_logLL"] = gamma_logLL
 
-        adata.var.loc[valid_ind, kin_param_pre + "bs"] = bs
-        adata.var.loc[valid_ind, kin_param_pre + "bf"] = bf
+        params_df.loc[valid_ind, kin_param_pre + "bs"] = bs
+        params_df.loc[valid_ind, kin_param_pre + "bf"] = bf
 
-        adata.var.loc[valid_ind, kin_param_pre + "uu0"] = uu0
-        adata.var.loc[valid_ind, kin_param_pre + "ul0"] = ul0
-        adata.var.loc[valid_ind, kin_param_pre + "su0"] = su0
-        adata.var.loc[valid_ind, kin_param_pre + "sl0"] = sl0
-        adata.var.loc[valid_ind, kin_param_pre + "U0"] = U0
-        adata.var.loc[valid_ind, kin_param_pre + "S0"] = S0
-        adata.var.loc[valid_ind, kin_param_pre + "total0"] = total0
+        params_df.loc[valid_ind, kin_param_pre + "uu0"] = uu0
+        params_df.loc[valid_ind, kin_param_pre + "ul0"] = ul0
+        params_df.loc[valid_ind, kin_param_pre + "su0"] = su0
+        params_df.loc[valid_ind, kin_param_pre + "sl0"] = sl0
+        params_df.loc[valid_ind, kin_param_pre + "U0"] = U0
+        params_df.loc[valid_ind, kin_param_pre + "S0"] = S0
+        params_df.loc[valid_ind, kin_param_pre + "total0"] = total0
 
         if experiment_type == "one-shot":
-            adata.var[kin_param_pre + "beta_k"] = None
-            adata.var[kin_param_pre + "gamma_k"] = None
-            adata.var.loc[valid_ind, kin_param_pre + "beta_k"] = beta_k
-            adata.var.loc[valid_ind, kin_param_pre + "gamma_k"] = gamma_k
+            params_df[kin_param_pre + "beta_k"] = None
+            params_df[kin_param_pre + "gamma_k"] = None
+            params_df.loc[valid_ind, kin_param_pre + "beta_k"] = beta_k
+            params_df.loc[valid_ind, kin_param_pre + "gamma_k"] = gamma_k
 
         if ind_for_proteins is not None:
             delta_r2[~np.isfinite(delta_r2)] = 0
             if cur_grp == _group[0]:
                 (
-                    adata.var[kin_param_pre + "eta"],
-                    adata.var[kin_param_pre + "delta"],
-                    adata.var[kin_param_pre + "delta_b"],
-                    adata.var[kin_param_pre + "delta_r2"],
-                    adata.var[kin_param_pre + "p_half_life"],
+                    params_df[kin_param_pre + "eta"],
+                    params_df[kin_param_pre + "delta"],
+                    params_df[kin_param_pre + "delta_b"],
+                    params_df[kin_param_pre + "delta_r2"],
+                    params_df[kin_param_pre + "p_half_life"],
                 ) = (None, None, None, None, None)
-            adata.var.loc[valid_ind, kin_param_pre + "eta"][ind_for_proteins] = eta
-            adata.var.loc[valid_ind, kin_param_pre + "delta"][ind_for_proteins] = delta
-            adata.var.loc[valid_ind, kin_param_pre + "delta_b"][ind_for_proteins] = delta_intercept
-            adata.var.loc[valid_ind, kin_param_pre + "delta_r2"][ind_for_proteins] = delta_r2
-            adata.var.loc[valid_ind, kin_param_pre + "p_half_life"][ind_for_proteins] = np.log(2) / delta
+            params_df.loc[valid_ind, kin_param_pre + "eta"][ind_for_proteins] = eta
+            params_df.loc[valid_ind, kin_param_pre + "delta"][ind_for_proteins] = delta
+            params_df.loc[valid_ind, kin_param_pre + "delta_b"][ind_for_proteins] = delta_intercept
+            params_df.loc[valid_ind, kin_param_pre + "delta_r2"][ind_for_proteins] = delta_r2
+            params_df.loc[valid_ind, kin_param_pre + "p_half_life"][ind_for_proteins] = np.log(2) / delta
+
+    adata.uns[kin_param_pre + "params"] = params_df
 
     return adata
 

--- a/dynamo/tools/utils.py
+++ b/dynamo/tools/utils.py
@@ -1662,6 +1662,21 @@ def get_vel_params(
     return tuple(target_params)
 
 
+def update_vel_params(adata: AnnData, params_df: pd.DataFrame, kin_param_pre: str = "") -> None:
+    """Update the velocity parameters.
+
+    Args:
+        adata: the AnnData obejct to update.
+        params_df: the new velocity parameters.
+        kin_param_pre: the prefix to locate the corresponding parameters.
+
+    Returns:
+        The anndata object will be updated.
+    """
+    adata.varm[kin_param_pre + "vel_params"] = params_df.to_numpy()
+    adata.uns[kin_param_pre + "vel_params_names"] = list(params_df.columns)
+
+
 def get_U_S_for_velocity_estimation(subset_adata, use_moments, has_splicing, has_labeling, log_unnormalized, NTR):
     mapper = get_mapper()
 

--- a/dynamo/tools/utils.py
+++ b/dynamo/tools/utils.py
@@ -1621,6 +1621,18 @@ def get_vel_params(
     kin_param_pre: str = "",
     skip_cell_wise: bool = False,
 ) -> Tuple:
+    """Get the velocity parameters based on input names.
+
+    Args:
+        adata: the anndata object which contains the parameters.
+        params: the names of parameters to query,
+        kin_param_pre: the prefix used in dynamics when estimating the parameters.
+        skip_cell_wise: whether to skip the detected cell wise parameters. If set to True, the mean will be returned
+            instead of cell wise parameters.
+
+    Returns:
+        All velocity parameters with the same order of query `params`.
+    """
     if type(params) is str:
         params = [params]
 

--- a/dynamo/tools/velocyto_scvelo.py
+++ b/dynamo/tools/velocyto_scvelo.py
@@ -37,17 +37,23 @@ def vlm_to_adata(
 
     # set obs, var
     obs, var = pd.DataFrame(vlm.ca), pd.DataFrame(vlm.ra)
+    vel_params = []
+    vel_params_names = []
+    varm = {}
     if "CellID" in obs.keys():
         obs["obs_names"] = obs.pop("CellID")
     if "Gene" in var.keys():
         var["var_names"] = var.pop("Gene")
 
     if hasattr(vlm, "q"):
-        var["gamma_b"] = vlm.q
+        vel_params_names.append("gamma_b")
+        vel_params.append(vlm.q)
     if hasattr(vlm, "gammas"):
-        var["gamma"] = vlm.gammas
+        vel_params_names.append("gamma")
+        vel_params.append(vlm.gammas)
     if hasattr(vlm, "R2"):
-        var["gamma_r2"] = vlm.R2
+        vel_params_names.append("gamma_r2")
+        vel_params.append(vlm.R2)
 
     # rename clusters to louvain
     try:
@@ -158,7 +164,11 @@ def vlm_to_adata(
         X = csr_matrix(vlm.S_sz.T) if hasattr(vlm, "S_sz") else csr_matrix(vlm.S.T)
 
     # create an anndata object with Dynamo characteristics.
-    dyn_adata = anndata.AnnData(X=X, obs=obs, obsp=obsp, obsm=obsm, var=var, layers=layers, uns=uns)
+    if len(vel_params_names) > 0:
+        uns["vel_params_names"] = vel_params_names
+        varm["vel_params"] = vel_params
+
+    dyn_adata = anndata.AnnData(X=X, obs=obs, obsp=obsp, obsm=obsm, var=var, varm=varm, layers=layers, uns=uns)
 
     return dyn_adata
 


### PR DESCRIPTION
Use a matrix called `vel_params` in `.varm` to replace all velocity parameters in `.var`. Column names will be saved in `.uns` as `vel_params_names`.  Cell-wise velocity will remain the same. Helper functions to read and update the parameters are created.