### PR TITLE
Debug h5ad saving

### DIFF
--- a/dynamo/data_io.py
+++ b/dynamo/data_io.py
@@ -383,20 +383,28 @@ def import_kmc(adata):
 
 def export_h5ad(adata, path="data/processed_data.h5ad"):
     convert_velocity_params_type(adata)
+    if "kmc" in adata.uns.keys():
+        export_kmc(adata)
     fate_keys = [i if i.startswith("fate") else None for i in adata.uns_keys()]
     for i in fate_keys:
         if i is not None:
             if "prediction" in adata.uns[i].keys():
                 adata.uns[i]["prediction"] = {str(index): array for index, array in enumerate(adata.uns[i]["prediction"])}
+            if "t" in adata.uns[i].keys():
+                adata.uns[i]["t"] = {str(index): array for index, array in enumerate(adata.uns[i]["t"])}
     adata.write_h5ad(path)
 
 
 def import_h5ad(path="data/processed_data.h5ad"):
     adata = read_h5ad(path)
+    if "kmc_params" in adata.uns.keys():
+        import_kmc(adata)
     fate_keys = [i if i.startswith("fate") else None for i in adata.uns_keys()]
     for i in fate_keys:
         if i is not None:
             if "prediction" in adata.uns[i].keys():
-                adata.uns[i]["prediction"] = [adata.uns[i]["prediction"]["NCx"][index] for index in adata.uns[i]["prediction"]]
+                adata.uns[i]["prediction"] = [adata.uns[i]["prediction"][index] for index in adata.uns[i]["prediction"]]
+            if "t" in adata.uns[i].keys():
+                adata.uns[i]["t"] = [adata.uns[i]["t"][index] for index in adata.uns[i]["t"]]
     return adata
 

--- a/dynamo/data_io.py
+++ b/dynamo/data_io.py
@@ -373,6 +373,15 @@ def export_h5ad(adata: AnnData, path: str = "data/processed_data.h5ad") -> None:
     if "kmc" in adata.uns.keys():
         export_kmc(adata)
 
+    fate_keys = [i if i.startswith("fate") else None for i in adata.uns_keys()]
+    for i in fate_keys:
+        if i is not None:
+            if "prediction" in adata.uns[i].keys():
+                adata.uns[i]["prediction"] = {str(index): array for index, array in
+                                              enumerate(adata.uns[i]["prediction"])}
+            if "t" in adata.uns[i].keys():
+                adata.uns[i]["t"] = {str(index): array for index, array in enumerate(adata.uns[i]["t"])}
+
     adata.write_h5ad(path)
 
 
@@ -382,6 +391,14 @@ def import_h5ad(path: str ="data/processed_data.h5ad") -> AnnData:
     adata = read_h5ad(path)
     if "kmc_params" in adata.uns.keys():
         import_kmc(adata)
+
+    fate_keys = [i if i.startswith("fate") else None for i in adata.uns_keys()]
+    for i in fate_keys:
+        if i is not None:
+            if "prediction" in adata.uns[i].keys():
+                adata.uns[i]["prediction"] = [adata.uns[i]["prediction"][index] for index in adata.uns[i]["prediction"]]
+            if "t" in adata.uns[i].keys():
+                adata.uns[i]["t"] = [adata.uns[i]["t"][index] for index in adata.uns[i]["t"]]
 
     return adata
 

--- a/dynamo/data_io.py
+++ b/dynamo/data_io.py
@@ -20,6 +20,7 @@ from anndata import (
 from tqdm import tqdm
 
 from .dynamo_logger import main_info
+from .tools.Markov import KernelMarkovChain
 
 
 def make_dir(path: str, can_exist=True):
@@ -351,6 +352,33 @@ def export_rank_xlsx(adata, path="rank_info.xlsx", ext="excel", rank_prefix="ran
             if key[: len(rank_prefix)] == rank_prefix:
                 main_info("saving sheet: " + str(key))
                 adata.uns[key].to_excel(writer, sheet_name=str(key))
+
+
+def export_kmc(adata):
+    kmc = adata.uns["kmc"]
+    adata.uns["kmc_params"] = {
+        "P": kmc.P,
+        "Idx": kmc.Idx,
+        "eignum": kmc.eignum,
+        "D": kmc.D,
+        "U": kmc.U,
+        "W": kmc.W,
+        "W_inv": kmc.W_inv,
+        "Kd": kmc.Kd,
+    }
+    adata.uns.pop("kmc")
+
+
+def import_kmc(adata):
+    kmc = KernelMarkovChain(P=adata.uns["kmc_params"]["P"], Idx=adata.uns["kmc_params"]["Idx"])
+    kmc.eignum = adata.uns["kmc_params"]["eignum"]
+    kmc.D = adata.uns["kmc_params"]["D"]
+    kmc.U = adata.uns["kmc_params"]["U"]
+    kmc.W = adata.uns["kmc_params"]["W"]
+    kmc.W_inv = adata.uns["kmc_params"]["W_inv"]
+    kmc.Kd = adata.uns["kmc_params"]["Kd"]
+    adata.uns["kmc"] = kmc
+    adata.uns.pop("kmc_params")
 
 
 def export_h5ad(adata, path="data/processed_data.h5ad"):

--- a/dynamo/data_io.py
+++ b/dynamo/data_io.py
@@ -354,7 +354,8 @@ def export_rank_xlsx(adata, path="rank_info.xlsx", ext="excel", rank_prefix="ran
                 adata.uns[key].to_excel(writer, sheet_name=str(key))
 
 
-def export_kmc(adata):
+def export_kmc(adata: AnnData) -> None:
+    """Save the parameters of kmc and delete the kmc object from anndata."""
     kmc = adata.uns["kmc"]
     adata.uns["kmc_params"] = {
         "P": kmc.P,
@@ -369,7 +370,8 @@ def export_kmc(adata):
     adata.uns.pop("kmc")
 
 
-def import_kmc(adata):
+def import_kmc(adata: AnnData) -> None:
+    """Construct the kmc object using the parameters saved."""
     kmc = KernelMarkovChain(P=adata.uns["kmc_params"]["P"], Idx=adata.uns["kmc_params"]["Idx"])
     kmc.eignum = adata.uns["kmc_params"]["eignum"]
     kmc.D = adata.uns["kmc_params"]["D"]
@@ -381,7 +383,8 @@ def import_kmc(adata):
     adata.uns.pop("kmc_params")
 
 
-def export_h5ad(adata, path="data/processed_data.h5ad"):
+def export_h5ad(adata: AnnData, path: str = "data/processed_data.h5ad") -> None:
+    """Export the anndata object to h5ad."""
     convert_velocity_params_type(adata)
     if "kmc" in adata.uns.keys():
         export_kmc(adata)
@@ -395,7 +398,8 @@ def export_h5ad(adata, path="data/processed_data.h5ad"):
     adata.write_h5ad(path)
 
 
-def import_h5ad(path="data/processed_data.h5ad"):
+def import_h5ad(path: str ="data/processed_data.h5ad") -> AnnData:
+    """Import a Dynamo h5ad object into anndata."""
     adata = read_h5ad(path)
     if "kmc_params" in adata.uns.keys():
         import_kmc(adata)

--- a/dynamo/data_io.py
+++ b/dynamo/data_io.py
@@ -355,4 +355,20 @@ def export_rank_xlsx(adata, path="rank_info.xlsx", ext="excel", rank_prefix="ran
 
 def export_h5ad(adata, path="data/processed_data.h5ad"):
     convert_velocity_params_type(adata)
+    fate_keys = [i if i.startswith("fate") else None for i in adata.uns_keys()]
+    for i in fate_keys:
+        if i is not None:
+            if "prediction" in adata.uns[i].keys():
+                adata.uns[i]["prediction"] = {str(index): array for index, array in enumerate(adata.uns[i]["prediction"])}
     adata.write_h5ad(path)
+
+
+def import_h5ad(path="data/processed_data.h5ad"):
+    adata = read_h5ad(path)
+    fate_keys = [i if i.startswith("fate") else None for i in adata.uns_keys()]
+    for i in fate_keys:
+        if i is not None:
+            if "prediction" in adata.uns[i].keys():
+                adata.uns[i]["prediction"] = [adata.uns[i]["prediction"]["NCx"][index] for index in adata.uns[i]["prediction"]]
+    return adata
+

--- a/dynamo/plot/topography.py
+++ b/dynamo/plot/topography.py
@@ -243,7 +243,7 @@ def plot_nullclines(
     NCx, NCy = None, None
 
     # if nullcline is not previously calculated, calculate and plot them
-    if vecfld_dict is None or "nullcline" not in vecfld_dict.keys():
+    if vecfld_dict is None or "NCx" not in vecfld_dict.keys() or "NCy" not in vecfld_dict.keys():
         if vecfld_dict is not None:
             X_basis = vecfld_dict["X"][:, :2]
             min_, max_ = X_basis.min(0), X_basis.max(0)
@@ -265,7 +265,10 @@ def plot_nullclines(
 
                 NCx, NCy = vecfld2d.NCx, vecfld.NCy
     else:
-        NCx, NCy = vecfld_dict["nullcline"][0], vecfld_dict["nullcline"][1]
+        NCx, NCy = (
+            [vecfld_dict["NCx"][index] for index in vecfld_dict["NCx"]],
+            [vecfld_dict["NCy"][index] for index in vecfld_dict["NCy"]],
+        )
 
     if ax is None:
         ax = plt.gca()

--- a/dynamo/prediction/fate.py
+++ b/dynamo/prediction/fate.py
@@ -16,7 +16,7 @@ from ..dynamo_logger import (
     main_info_insert_adata,
     main_warning,
 )
-from ..preprocessing.pca import pca_inverse_transform
+from ..utils import pca_to_expr
 from ..tools.connectivity import construct_mapper_umap
 from ..tools.utils import fetch_states, getTseq
 from ..vectorfield import vector_field_function
@@ -193,7 +193,7 @@ def fate(
 
         if "X" in adata.obsm_keys():
             if ndim == adata.obsm[DKM.X_PCA].shape[1]:  # lift the dimension up again
-                exprs = pca_inverse_transform(prediction, PCs=PCs.T, mean=adata.uns["pca_mean"])
+                exprs = pca_to_expr(prediction, PCs=PCs.T, mean=adata.uns["pca_mean"])
 
         if adata.var.use_for_dynamics.sum() == exprs.shape[1]:
             valid_genes = adata.var_names[adata.var.use_for_dynamics]

--- a/dynamo/prediction/fate.py
+++ b/dynamo/prediction/fate.py
@@ -16,6 +16,7 @@ from ..dynamo_logger import (
     main_info_insert_adata,
     main_warning,
 )
+from ..preprocessing.pca import pca_inverse_transform
 from ..tools.connectivity import construct_mapper_umap
 from ..tools.utils import fetch_states, getTseq
 from ..vectorfield import vector_field_function
@@ -192,7 +193,7 @@ def fate(
 
         if "X" in adata.obsm_keys():
             if ndim == adata.obsm[DKM.X_PCA].shape[1]:  # lift the dimension up again
-                exprs = adata.uns["pca_fit"].inverse_transform(prediction)
+                exprs = pca_inverse_transform(prediction, PCs=PCs.T, mean=adata.uns["pca_mean"])
 
         if adata.var.use_for_dynamics.sum() == exprs.shape[1]:
             valid_genes = adata.var_names[adata.var.use_for_dynamics]

--- a/dynamo/prediction/fate.py
+++ b/dynamo/prediction/fate.py
@@ -207,12 +207,12 @@ def fate(
 
     adata.uns[fate_key] = {
         "init_states": init_states,
-        "init_cells": init_cells,
+        "init_cells": list(init_cells),
         "average": average,
         "t": t,
         "prediction": prediction,
         # "VecFld": VecFld,
-        "VecFld_true": VecFld_true,
+        # "VecFld_true": VecFld_true,
         "genes": valid_genes,
     }
     if exprs is not None:

--- a/dynamo/prediction/fate.py
+++ b/dynamo/prediction/fate.py
@@ -16,6 +16,7 @@ from ..dynamo_logger import (
     main_info_insert_adata,
     main_warning,
 )
+from ..tools.connectivity import construct_mapper_umap
 from ..tools.utils import fetch_states, getTseq
 from ..vectorfield import vector_field_function
 from ..vectorfield.utils import vecfld_from_adata, vector_transformation
@@ -164,14 +165,30 @@ def fate(
         # this requires umap 0.4; reverse project to PCA space.
         if prediction.ndim == 1:
             prediction = prediction[None, :]
-        exprs = adata.uns["umap_fit"]["fit"].inverse_transform(prediction)
+
+        params = adata.uns["umap_fit"]
+        mapper = construct_mapper_umap(
+            params["X_data"],
+            n_components=params["umap_kwargs"]["n_components"],
+            metric=params["umap_kwargs"]["metric"],
+            min_dist=params["umap_kwargs"]["min_dist"],
+            spread=params["umap_kwargs"]["spread"],
+            max_iter=params["umap_kwargs"]["max_iter"],
+            alpha=params["umap_kwargs"]["alpha"],
+            gamma=params["umap_kwargs"]["gamma"],
+            negative_sample_rate=params["umap_kwargs"]["negative_sample_rate"],
+            init_pos=params["umap_kwargs"]["init_pos"],
+            random_state=params["umap_kwargs"]["random_state"],
+            umap_kwargs=params["umap_kwargs"],
+        )
+        exprs = mapper.inverse_transform(prediction)
 
         # further reverse project back to raw expression space
         PCs = adata.uns["PCs"].T
         if PCs.shape[0] == exprs.shape[1]:
             exprs = np.expm1(exprs @ PCs + adata.uns["pca_mean"])
 
-        ndim = adata.uns["umap_fit"]["fit"]._raw_data.shape[1]
+        ndim = mapper._raw_data.shape[1]
 
         if "X" in adata.obsm_keys():
             if ndim == adata.obsm[DKM.X_PCA].shape[1]:  # lift the dimension up again

--- a/dynamo/prediction/least_action_path.py
+++ b/dynamo/prediction/least_action_path.py
@@ -601,7 +601,7 @@ def least_action(
 
     adata.uns[LAP_key] = {
         "init_states": init_states,
-        "init_cells": init_cells,
+        "init_cells": list(init_cells),
         "t": t,
         "mftp": mftp,
         "prediction": prediction,

--- a/dynamo/prediction/least_action_path.py
+++ b/dynamo/prediction/least_action_path.py
@@ -8,6 +8,7 @@ from scipy.optimize import minimize
 
 from ..dynamo_logger import LoggerManager
 from ..tools.utils import fetch_states, nearest_neighbors
+from ..utils import pca_to_expr
 from ..vectorfield import SvcVectorField
 from ..vectorfield.utils import (
     vecfld_from_adata,
@@ -15,7 +16,7 @@ from ..vectorfield.utils import (
     vector_transformation,
 )
 from .trajectory import GeneTrajectory, Trajectory
-from .utils import arclength_sampling_n, find_elbow, pca_to_expr
+from .utils import arclength_sampling_n, find_elbow
 
 
 class LeastActionPath(Trajectory):

--- a/dynamo/prediction/perturbation.py
+++ b/dynamo/prediction/perturbation.py
@@ -7,6 +7,7 @@ from scipy.sparse import csr_matrix
 
 from ..dynamo_logger import LoggerManager
 from ..tools.cell_velocities import cell_velocities
+from ..utils import expr_to_pca, pca_to_expr
 from ..vectorfield import SvcVectorField
 from ..vectorfield.scVectorField import KOVectorField, vector_field_function_knockout
 from ..vectorfield.vector_calculus import (
@@ -15,7 +16,7 @@ from ..vectorfield.vector_calculus import (
     vector_transformation,
 )
 from ..vectorfield.rank_vf import rank_cell_groups, rank_cells, rank_genes
-from .utils import expr_to_pca, pca_to_expr, z_score, z_score_inv
+from .utils import z_score, z_score_inv
 
 
 def KO(

--- a/dynamo/prediction/trajectory.py
+++ b/dynamo/prediction/trajectory.py
@@ -5,9 +5,10 @@ from scipy.interpolate import interp1d
 
 from ..dynamo_logger import LoggerManager
 from ..tools.utils import flatten
+from ..utils import expr_to_pca, pca_to_expr
 from ..vectorfield.scVectorField import DifferentiableVectorField
 from ..vectorfield.utils import angle, normalize_vectors
-from .utils import arclength_sampling_n, expr_to_pca, pca_to_expr
+from .utils import arclength_sampling_n
 
 
 class Trajectory:

--- a/dynamo/prediction/utils.py
+++ b/dynamo/prediction/utils.py
@@ -473,7 +473,7 @@ def arclength_sampling(X, step_length, n_steps: int, t=None):
         if L + d < step_length:
             terminate = True
 
-    if terminate and len(Y) < n_steps:
+    if len(Y) < n_steps:
         _, _ = _calculate_new_point()
 
     if T is not None:

--- a/dynamo/prediction/utils.py
+++ b/dynamo/prediction/utils.py
@@ -484,30 +484,6 @@ def arclength_sampling_n(X, num, t=None):
 
 
 # ---------------------------------------------------------------------------------------------------
-# trajectory related
-def pca_to_expr(X, PCs, mean=0, func=None):
-    # reverse project from PCA back to raw expression space
-    if PCs.shape[1] == X.shape[1]:
-        exprs = X @ PCs.T + mean
-        if func is not None:
-            exprs = func(exprs)
-    else:
-        raise Exception("PCs dim 1 (%d) does not match X dim 1 (%d)." % (PCs.shape[1], X.shape[1]))
-    return exprs
-
-
-def expr_to_pca(expr, PCs, mean=0, func=None):
-    # project from raw expression space to PCA
-    if PCs.shape[0] == expr.shape[1]:
-        X = (expr - mean) @ PCs
-        if func is not None:
-            X = func(X)
-    else:
-        raise Exception("PCs dim 1 (%d) does not match X dim 1 (%d)." % (PCs.shape[0], expr.shape[1]))
-    return X
-
-
-# ---------------------------------------------------------------------------------------------------
 # fate related
 def fetch_exprs(adata, basis, layer, genes, time, mode, project_back_to_high_dim, traj_ind):
     import pandas as pd

--- a/dynamo/preprocessing/cell_cycle.py
+++ b/dynamo/preprocessing/cell_cycle.py
@@ -418,7 +418,8 @@ def get_cell_phase(
     else:
         cell_phase_genes = gene_list
 
-    adata.uns["cell_phase_genes"] = cell_phase_genes
+    adata.uns["cell_phase_genes_order"] = [key for key in cell_phase_genes]
+    adata.uns["cell_phase_genes"] = dict(cell_phase_genes)
     # score each cell cycle phase and Z-normalize
     phase_scores = pd.DataFrame(batch_group_score(adata, layer, cell_phase_genes))
     normalized_phase_scores = phase_scores.sub(phase_scores.mean(axis=1), axis=0).div(phase_scores.std(axis=1), axis=0)

--- a/dynamo/preprocessing/cell_cycle.py
+++ b/dynamo/preprocessing/cell_cycle.py
@@ -418,7 +418,7 @@ def get_cell_phase(
     else:
         cell_phase_genes = gene_list
 
-    adata.uns["cell_phase_genes_order"] = [key for key in cell_phase_genes]
+    adata.uns["cell_phase_order"] = [key for key in cell_phase_genes]
     adata.uns["cell_phase_genes"] = dict(cell_phase_genes)
     # score each cell cycle phase and Z-normalize
     phase_scores = pd.DataFrame(batch_group_score(adata, layer, cell_phase_genes))

--- a/dynamo/preprocessing/pca.py
+++ b/dynamo/preprocessing/pca.py
@@ -358,34 +358,3 @@ def top_pca_genes(
     main_info_insert_adata_var(adata_store_key, indent_level=2)
     adata.var[adata_store_key] = genes
     return adata
-
-
-def pca_transform(data: Union[np.ndarray, csr_matrix], PCs: np.ndarray) -> np.ndarray:
-    """Transform the data with given principal components.
-
-    Args:
-        data: raw data to transform.
-        PCs: the principal components.
-
-    Returns:
-        The transformed data.
-    """
-    arr = data.toarray().copy() if issparse(data) else data.copy()
-    mean = arr.mean(0)
-    centered_data = arr - mean
-    return np.dot(centered_data, PCs)
-
-
-def pca_inverse_transform(data: Union[np.ndarray, csr_matrix], PCs: np.ndarray, mean: np.ndarray) -> np.ndarray:
-    """Inverse transform the data with given principal components.
-
-    Args:
-        data: raw data to transform.
-        PCs: the principal components.
-        mean: the mean used to fit the PCA.
-
-    Returns:
-        The inverse transformed data.
-    """
-    arr = data.toarray().copy() if issparse(data) else data.copy()
-    return np.dot(arr, PCs.T) + mean

--- a/dynamo/preprocessing/pca.py
+++ b/dynamo/preprocessing/pca.py
@@ -358,3 +358,15 @@ def top_pca_genes(
     main_info_insert_adata_var(adata_store_key, indent_level=2)
     adata.var[adata_store_key] = genes
     return adata
+
+
+def pca_transform(data: Union[np.ndarray, csr_matrix], PCs: np.ndarray) -> np.ndarray:
+    arr = data.toarray().copy() if issparse(data) else data.copy()
+    mean = arr.mean(0)
+    centered_data = arr - mean
+    return np.dot(centered_data, PCs)
+
+
+def pca_inverse_transform(data: Union[np.ndarray, csr_matrix], PCs: np.ndarray, mean: np.ndarray) -> np.ndarray:
+    arr = data.toarray().copy() if issparse(data) else data.copy()
+    return np.dot(arr, PCs.T) + mean

--- a/dynamo/preprocessing/pca.py
+++ b/dynamo/preprocessing/pca.py
@@ -361,6 +361,15 @@ def top_pca_genes(
 
 
 def pca_transform(data: Union[np.ndarray, csr_matrix], PCs: np.ndarray) -> np.ndarray:
+    """Transform the data with given principal components.
+
+    Args:
+        data: raw data to transform.
+        PCs: the principal components.
+
+    Returns:
+        The transformed data.
+    """
     arr = data.toarray().copy() if issparse(data) else data.copy()
     mean = arr.mean(0)
     centered_data = arr - mean
@@ -368,5 +377,15 @@ def pca_transform(data: Union[np.ndarray, csr_matrix], PCs: np.ndarray) -> np.nd
 
 
 def pca_inverse_transform(data: Union[np.ndarray, csr_matrix], PCs: np.ndarray, mean: np.ndarray) -> np.ndarray:
+    """Inverse transform the data with given principal components.
+
+    Args:
+        data: raw data to transform.
+        PCs: the principal components.
+        mean: the mean used to fit the PCA.
+
+    Returns:
+        The inverse transformed data.
+    """
     arr = data.toarray().copy() if issparse(data) else data.copy()
     return np.dot(arr, PCs.T) + mean

--- a/dynamo/tools/cell_velocities.py
+++ b/dynamo/tools/cell_velocities.py
@@ -535,18 +535,19 @@ def cell_velocities(
             umap_kwargs=params["umap_kwargs"],
         )
 
-        if "pca_fit" not in adata.uns_keys() or type(adata.uns["pca_fit"]) == str:
-            CM = adata.X[:, adata.var.use_for_dynamics.values]
+        CM = adata.X[:, adata.var.use_for_dynamics.values]
+        if "PCs" not in adata.uns_keys():
             from ..preprocessing.pca import pca
 
             adata, pca_fit, X_pca = pca(adata, CM, params["n_pca_components"], "X", return_all=True)
-            adata.uns["pca_fit"] = pca_fit
 
-        X_pca, pca_fit = adata.obsm[DKM.X_PCA], adata.uns["pca_fit"]
+        from ..preprocessing.pca import pca_transform
+
+        X_pca, pca_PCs = adata.obsm[DKM.X_PCA], adata.uns["PCs"]
         V = adata[:, adata.var.use_for_dynamics.values].layers[vkey] if vkey in adata.layers.keys() else None
         CM, V = CM.A if sp.issparse(CM) else CM, V.A if sp.issparse(V) else V
         V[np.isnan(V)] = 0
-        Y_pca = pca_fit.transform(CM + V)
+        Y_pca = pca_transform(CM + V, PCs=pca_PCs)
 
         Y = umap_trans.transform(Y_pca)
 

--- a/dynamo/tools/connectivity.py
+++ b/dynamo/tools/connectivity.py
@@ -532,8 +532,9 @@ def mnn(
     """
 
     if use_pca_fit:
-        if "pca_fit" in adata.uns.keys():
-            fiter = adata.uns["pca_fit"]
+        from ..preprocessing.pca import pca_transform
+        if "PCs" in adata.uns.keys():
+            PCs = adata.uns["PCs"]
         else:
             raise Exception("use_pca_fit is set to be True, but there is no pca fit results in .uns attribute.")
 
@@ -548,7 +549,7 @@ def mnn(
         layer_X = adata.layers[layer]
         layer_X = log1p_(adata, layer_X)
         if use_pca_fit:
-            layer_pca = fiter.fit_transform(layer_X)[:, 1:]
+            layer_pca = pca_transform(layer_X, PCs)[:, 1:]
         else:
             transformer = TruncatedSVD(n_components=n_pca_components + 1, random_state=0)
             layer_pca = transformer.fit_transform(layer_X)[:, 1:]

--- a/dynamo/tools/connectivity.py
+++ b/dynamo/tools/connectivity.py
@@ -21,6 +21,7 @@ from umap import UMAP
 from ..configuration import DynamoAdataKeyManager
 from ..docrep import DocstringProcessor
 from ..dynamo_logger import LoggerManager, main_info, main_warning
+from ..utils import expr_to_pca
 from .utils import fetch_X_data, log1p_
 
 docstrings = DocstringProcessor()
@@ -532,7 +533,6 @@ def mnn(
     """
 
     if use_pca_fit:
-        from ..preprocessing.pca import pca_transform
         if "PCs" in adata.uns.keys():
             PCs = adata.uns["PCs"]
         else:
@@ -549,7 +549,7 @@ def mnn(
         layer_X = adata.layers[layer]
         layer_X = log1p_(adata, layer_X)
         if use_pca_fit:
-            layer_pca = pca_transform(layer_X, PCs)[:, 1:]
+            layer_pca = expr_to_pca(layer_X, PCs=PCs, mean=layer_X.mean(0))[:, 1:]
         else:
             transformer = TruncatedSVD(n_components=n_pca_components + 1, random_state=0)
             layer_pca = transformer.fit_transform(layer_X)[:, 1:]

--- a/dynamo/tools/markers.py
+++ b/dynamo/tools/markers.py
@@ -292,7 +292,9 @@ def find_group_markers(
     de_table = pd.concat(de_tables).reset_index().drop(columns=["index"])
     de_table["log2_fc"] = de_table["log2_fc"].astype("float")
 
-    adata.uns["cluster_markers"] = {"deg_table": de_table, "de_genes": de_genes}
+    adata.uns["cluster_markers"] = {"deg_table": de_table}
+    for key, value in de_genes.items():
+        adata.uns["cluster_markers"]["de_genes" + str(key)] = value
 
     return adata
 
@@ -430,7 +432,7 @@ def two_groups_degs(
                 log_fc = test_vals.mean() - control_vals.mean()  # for curvature, acceleration, log fc is meaningless
 
             try:
-                u, mw_p = mannwhitneyu(test_vals, control_vals)
+                u, mw_p = map(float, mannwhitneyu(test_vals, control_vals))
             except ValueError:
                 pass
             else:

--- a/dynamo/tools/utils.py
+++ b/dynamo/tools/utils.py
@@ -1609,6 +1609,15 @@ def set_param_kinetic(
     return adata
 
 
+def convert_velocity_params_type(adata: AnnData) -> None:
+    velocity_param_names = ["beta", "gamma", "half_life", "alpha_b", "alpha_r2", "gamma_b", "gamma_r2", "gamma_logLL",
+                            "delta_b", "delta_r2", "bs", "bf", "uu0", "ul0", "su0", "sl0", "alpha", "a", "b", "alpha_a",
+                            "alpha_a", "alpha_i", "cost", "logLL"]
+    for param_name in velocity_param_names:
+        if param_name in adata.var.columns:
+            adata.var[param_name] = pd.to_numeric(adata.var[param_name], errors='coerce')
+
+
 def get_U_S_for_velocity_estimation(subset_adata, use_moments, has_splicing, has_labeling, log_unnormalized, NTR):
     mapper = get_mapper()
 

--- a/dynamo/tools/utils.py
+++ b/dynamo/tools/utils.py
@@ -26,13 +26,10 @@ from tqdm import tqdm
 
 from ..dynamo_logger import (
     LoggerManager,
-    main_critical,
     main_debug,
-    main_exception,
     main_info,
     main_info_insert_adata,
     main_info_verbose_timeit,
-    main_tqdm,
     main_warning,
 )
 from ..preprocessing.transform import _Freeman_Tukey
@@ -1607,22 +1604,6 @@ def set_param_kinetic(
     adata.var = var
 
     return adata
-
-
-def convert_velocity_params_type(adata: AnnData) -> None:
-    """Convert the velocity parameters into numeric type to avoid error when saving to h5ad.
-
-    The data type of the parameters in the Pandas Series is set to object due to the initialization of parameters with
-    None values. However, this choice of data type can lead to errors during the process of saving the anndata object.
-    Therefore, it becomes necessary to convert these parameters to a numeric data type to ensure proper handling and
-    compatibility.
-    """
-    velocity_param_names = ["beta", "gamma", "half_life", "alpha_b", "alpha_r2", "gamma_b", "gamma_r2", "gamma_logLL",
-                            "delta_b", "delta_r2", "bs", "bf", "uu0", "ul0", "su0", "sl0", "alpha", "a", "b", "alpha_a",
-                            "alpha_a", "alpha_i", "cost", "logLL"]
-    for param_name in velocity_param_names:
-        if param_name in adata.var.columns:
-            adata.var[param_name] = pd.to_numeric(adata.var[param_name], errors='coerce')
 
 
 def get_U_S_for_velocity_estimation(subset_adata, use_moments, has_splicing, has_labeling, log_unnormalized, NTR):

--- a/dynamo/tools/utils.py
+++ b/dynamo/tools/utils.py
@@ -1543,7 +1543,7 @@ def set_param_ss(
             params_df.loc[valid_ind, kin_param_pre + "delta_r2"][ind_for_proteins] = delta_r2
             params_df.loc[valid_ind, kin_param_pre + "p_half_life"][ind_for_proteins] = np.log(2) / delta
 
-    adata.varm[kin_param_pre + "vel_params"] = params_df.to_numpy()
+    adata.varm[kin_param_pre + "vel_params"] = params_df.to_numpy().astype(float)
     adata.uns[kin_param_pre + "vel_params_names"] = list(params_df.columns)
 
     return adata
@@ -1608,7 +1608,7 @@ def set_param_kinetic(
     extra_params.columns = [kin_param_pre + i for i in extra_params.columns]
     extra_params = extra_params.set_index(adata.var.index[valid_ind])
     var = pd.concat((params_df, extra_params), axis=1, sort=False)
-    adata.varm[kin_param_pre + "vel_params"] = var.to_numpy()
+    adata.varm[kin_param_pre + "vel_params"] = var.to_numpy().astype(float)
     adata.uns[kin_param_pre + "vel_params_names"] = list(var.columns)
 
     return adata

--- a/dynamo/tools/utils.py
+++ b/dynamo/tools/utils.py
@@ -1610,6 +1610,13 @@ def set_param_kinetic(
 
 
 def convert_velocity_params_type(adata: AnnData) -> None:
+    """Convert the velocity parameters into numeric type to avoid error when saving to h5ad.
+
+    The data type of the parameters in the Pandas Series is set to object due to the initialization of parameters with
+    None values. However, this choice of data type can lead to errors during the process of saving the anndata object.
+    Therefore, it becomes necessary to convert these parameters to a numeric data type to ensure proper handling and
+    compatibility.
+    """
     velocity_param_names = ["beta", "gamma", "half_life", "alpha_b", "alpha_r2", "gamma_b", "gamma_r2", "gamma_logLL",
                             "delta_b", "delta_r2", "bs", "bf", "uu0", "ul0", "su0", "sl0", "alpha", "a", "b", "alpha_a",
                             "alpha_a", "alpha_i", "cost", "logLL"]

--- a/dynamo/tools/utils_reduceDimension.py
+++ b/dynamo/tools/utils_reduceDimension.py
@@ -303,7 +303,6 @@ def run_reduce_dim(
         conn_key, dist_key, neighbor_key = _gen_neighbor_keys(neighbor_result_prefix)
 
         adata.uns["umap_fit"] = {
-            "fit": mapper,
             "X_data": X_data,
             "umap_kwargs": umap_kwargs,
             "n_pca_components": n_pca_components,

--- a/dynamo/tools/utils_reduceDimension.py
+++ b/dynamo/tools/utils_reduceDimension.py
@@ -304,6 +304,8 @@ def run_reduce_dim(
 
         adata.uns["umap_fit"] = {
             "fit": mapper,
+            "X_data": X_data,
+            "umap_kwargs": umap_kwargs,
             "n_pca_components": n_pca_components,
         }
     elif reduction_method == "psl":

--- a/dynamo/utils.py
+++ b/dynamo/utils.py
@@ -1,5 +1,7 @@
 """General utility functions
 """
+from typing import Callable, Dict, List, Optional, Tuple, Union
+
 import anndata
 import numpy as np
 import scipy.sparse as sp
@@ -82,7 +84,12 @@ def denormalize(y, x_min, x_max):
 
 # ---------------------------------------------------------------------------------------------------
 # trajectory related
-def pca_to_expr(X, PCs, mean=0, func=None):
+def pca_to_expr(
+    X: Union[np.ndarray, sp.csr_matrix],
+    PCs: np.ndarray,
+    mean: Union[int, np.ndarray] = 0,
+    func: Optional[Callable] = None,
+) -> np.ndarray:
     """Inverse transform the data with given principal components.
 
     Args:
@@ -105,7 +112,12 @@ def pca_to_expr(X, PCs, mean=0, func=None):
     return exprs
 
 
-def expr_to_pca(expr, PCs, mean=0, func=None):
+def expr_to_pca(
+    expr: Union[np.ndarray, sp.csr_matrix],
+    PCs: np.ndarray,
+    mean: Union[int, np.ndarray] = 0,
+    func: Optional[Callable] = None,
+) -> np.ndarray:
     """Transform the data with given principal components.
 
     Args:

--- a/dynamo/utils.py
+++ b/dynamo/utils.py
@@ -78,3 +78,51 @@ def normalize(x):
 
 def denormalize(y, x_min, x_max):
     return y * (x_max - x_min) + x_min
+
+
+# ---------------------------------------------------------------------------------------------------
+# trajectory related
+def pca_to_expr(X, PCs, mean=0, func=None):
+    """Inverse transform the data with given principal components.
+
+    Args:
+        X: raw data to transform.
+        PCs: the principal components.
+        mean: the mean used to fit the PCA.
+        func: additional function to transform the output.
+
+    Returns:
+        The inverse transformed data.
+    """
+    # reverse project from PCA back to raw expression space
+    X = X.toarray() if sp.issparse(X) else X
+    if PCs.shape[1] == X.shape[1]:
+        exprs = X @ PCs.T + mean
+        if func is not None:
+            exprs = func(exprs)
+    else:
+        raise Exception("PCs dim 1 (%d) does not match X dim 1 (%d)." % (PCs.shape[1], X.shape[1]))
+    return exprs
+
+
+def expr_to_pca(expr, PCs, mean=0, func=None):
+    """Transform the data with given principal components.
+
+    Args:
+        expr: raw data to transform.
+        PCs: the principal components.
+        mean: the mean of expr.
+        func: additional function to transform the output.
+
+    Returns:
+        The transformed data.
+    """
+    # project from raw expression space to PCA
+    expr = expr.toarray() if sp.issparse(expr) else expr
+    if PCs.shape[0] == expr.shape[1]:
+        X = (expr - mean) @ PCs
+        if func is not None:
+            X = func(X)
+    else:
+        raise Exception("PCs dim 1 (%d) does not match X dim 1 (%d)." % (PCs.shape[0], expr.shape[1]))
+    return X

--- a/dynamo/vectorfield/topography.py
+++ b/dynamo/vectorfield/topography.py
@@ -754,7 +754,8 @@ def topography(
                 "Xss": Xss,
                 "ftype": ftype,
                 "confidence": confidence,
-                "nullcline": [NCx, NCy],
+                "NCx": {str(index): array for index, array in enumerate(NCx)},
+                "NCy": {str(index): array for index, array in enumerate(NCy)},
                 "separatrices": None,
                 "fp_ind": fp_ind,
             }
@@ -767,7 +768,8 @@ def topography(
             "Xss": Xss,
             "ftype": ftype,
             "confidence": confidence,
-            "nullcline": [NCx, NCy],
+            "NCx": {str(index): array for index, array in enumerate(NCx)},
+            "NCy": {str(index): array for index, array in enumerate(NCy)},
             "separatrices": None,
             "fp_ind": fp_ind,
         }


### PR DESCRIPTION
Some parts of adata still have incompatible data types. Including:

- [x] fate output -> convert to a different format when saving, convert back when loading
- [x] kmc object -> convert to a different format when saving, convert back when loading
- [x] umap object -> now umap object will not be saved, it will be constructed with parameters when needed.
- [x] velocity parameters -> convert to compatible data type
- [x] cell phase genes -> convert to compatible data type
- [x] init cells -> convert to compatible data type
- [x] fixed points and nullclines  -> convert to compatible data type, nullclines are replaced by `NCx` and `NCy`

In the future, we will use `import_h5ad` and `export_h5ad` for saving and loading processed data.