### PR TITLE
Debug the cell_velocities

### DIFF
--- a/dynamo/tools/Markov.py
+++ b/dynamo/tools/Markov.py
@@ -8,7 +8,7 @@ from sklearn.decomposition import PCA
 from sklearn.neighbors import NearestNeighbors
 from tqdm import tqdm
 
-from ..dynamo_logger import LoggerManager
+from ..dynamo_logger import LoggerManager, main_warning
 from ..simulation.utils import directMethod
 from .utils import append_iterative_neighbor_indices, flatten
 
@@ -555,9 +555,12 @@ class MarkovChain:
                 0 - check if the matrix is column normalized;
                 1 - check if the matrix is row normalized.
         """
-        P = self.P if P is None else P
-        sumfunc = np.sum if not ignore_nan else np.nansum
-        return np.all(np.abs(sumfunc(P, axis=axis) - sumto) < tol)
+        if not P:
+            main_warning("No transition matrix input. Normalization check is skipped.")
+            return True
+        else:
+            sumfunc = np.sum if not ignore_nan else np.nansum
+            return np.all(np.abs(sumfunc(P, axis=axis) - sumto) < tol)
 
     def __reset__(self):
         self.D = None

--- a/dynamo/tools/cell_velocities.py
+++ b/dynamo/tools/cell_velocities.py
@@ -339,8 +339,8 @@ def cell_velocities(
     if method == "kmc" and n_pca_components is None:
         n_pca_components = 30
     if n_pca_components is not None:
-        X = log1p_(adata, X)
         X_plus_V = log1p_(adata, X + V)
+        X = log1p_(adata, X)
         if "velocity_pca_fit" not in adata.uns_keys() or type(adata.uns["velocity_pca_fit"]) == str:
             pca_monocle = PCA(
                 n_components=min(n_pca_components, X.shape[1] - 1),

--- a/dynamo/tools/cell_velocities.py
+++ b/dynamo/tools/cell_velocities.py
@@ -562,7 +562,8 @@ def cell_velocities(
     else:
         transition_key = add_transition_key
 
-    adata.obsp[transition_key] = T
+    if method != "transform":
+        adata.obsp[transition_key] = T
     if add_velocity_key is None:
         velocity_key, grid_velocity_key = "velocity_" + basis, "grid_velocity_" + basis
     else:


### PR DESCRIPTION
- [x] Debug this [issue](https://github.com/aristoteleo/dynamo-release/issues/571).
- [x] Debug incorrect X_plus_V calculation. It should be calculated with raw `X` instead of `X` after the log transform.
- [x] Debug the error of the transition matrix assignment. The "transform" method doesn't have a transition matrix to assign.

PS: kmc methods in `tl.cell_velocities` still have a [bug](https://github.com/aristoteleo/dynamo-release/issues/584) on negative velocities.