### PR TITLE
Debug arclength_sampling

### DIFF
--- a/dynamo/prediction/state_graph.py
+++ b/dynamo/prediction/state_graph.py
@@ -277,7 +277,7 @@ def state_graph(
                     )
 
                     if arc_sample:
-                        Y, arclength, T = arclength_sampling(Y, arclength / 1000, t=t[~T_bool])
+                        Y, arclength, T = arclength_sampling(Y, arclength / 1000, n_steps=1000, t=t[~T_bool])
                     else:
                         T = t[~T_bool]
                 else:


### PR DESCRIPTION
`arclength_sampling` uniformly samples data points on an arc curve that is generated from vector field predictions. However, it may terminate earlier than expected, resulting in inconsistent shapes in the output.

Proposed solution: When the length of output is smaller than expected, calculate a new point with the last set of parameters.