### PR TITLE
Debug arclength sampling

### DIFF
--- a/dynamo/prediction/utils.py
+++ b/dynamo/prediction/utils.py
@@ -473,7 +473,7 @@ def arclength_sampling(X, step_length, n_steps: int, t=None):
         if L + d < step_length:
             terminate = True
 
-    if terminate and len(Y) < n_steps:
+    if len(Y) < n_steps:
         _, _ = _calculate_new_point()
 
     if T is not None:


### PR DESCRIPTION
In pull request [586](https://github.com/aristoteleo/dynamo-release/pull/586), the function will sample one more point when `terminate` is True and the output length is insufficient. It turns out that the check of `terminate` is not necessary. Thus, this pull request will remove it.