### PR TITLE
Debug convert2symbol

### DIFF
--- a/dynamo/preprocessing/utils.py
+++ b/dynamo/preprocessing/utils.py
@@ -125,8 +125,12 @@ def convert2symbol(adata: AnnData, scopes: Union[str, Iterable, None] = None, su
         merge_df = adata.var.merge(official_gene_df, left_on="query", right_on="query", how="left").set_index(
             adata.var.index
         )
-        valid_ind = np.where(merge_df["notfound"] != True)[0]  # noqa: E712
-        merge_df.pop("notfound")
+        if "notfound" in merge_df.columns:
+            valid_ind = np.where(merge_df["notfound"] != True)[0]  # noqa: E712
+            merge_df.pop("notfound")
+        else:
+            valid_ind = np.arange(len(merge_df))
+
         adata.var = merge_df
 
         if subset is True:


### PR DESCRIPTION
Bug description: When we query the information from `mygene`, the output won't contain the "notfound" column if all genes can be found in the `mygene` database. This will raise a KeyError.

Solution: When "notfound" is not in the output, use all indices as the `valid_ind`.