### PR TITLE
Small adata Error fix

### DIFF
--- a/dynamo/preprocessing/gene_selection.py
+++ b/dynamo/preprocessing/gene_selection.py
@@ -237,9 +237,6 @@ def calc_dispersion_by_svr(
         # This is not picked up via None checks. (Empty valid_CM leads to a divide by 0 error in get_prediction_by_svr())
         # Note that simply doing `not valid_CM.toarray()` results in "truth value of array..." error due to numpy array
         # `not valid_CM.toarray().tolist()` doesn't work either because a list of empty lists still gives False
-        print(valid_CM.shape)
-        print(adata)
-        print(adata_ori)
         if valid_CM is None or valid_CM.shape[1] == 0:
             main_warning("No valid_CM for layer " + layer)
             

--- a/dynamo/preprocessing/gene_selection.py
+++ b/dynamo/preprocessing/gene_selection.py
@@ -233,14 +233,31 @@ def calc_dispersion_by_svr(
 
     for layer in layers:
         valid_CM, detected_bool = get_vaild_CM(adata, layer, **SVRs_kwargs)
-        if valid_CM is None:
-            continue
+        # valid_CM seems to be set as an empty sparse array when adata.var has too few rows. 
+        # This is not picked up via None checks. (Empty valid_CM leads to a divide by 0 error in get_prediction_by_svr())
+        # Note that simply doing `not valid_CM.toarray()` results in "truth value of array..." error due to numpy array
+        # `not valid_CM.toarray().tolist()` doesn't work either because a list of empty lists still gives False
+        print(valid_CM.shape)
+        print(adata)
+        print(adata_ori)
+        if valid_CM is None or valid_CM.shape[1] == 0:
+            main_warning("No valid_CM for layer " + layer)
+            
+            #If all layers are skipped then there will be no "score" column, causing a KeyError during preprocessing
+            #continue
 
-        mean, cv = get_mean_cv(adata, valid_CM, algorithm, winsorize, winsor_perc)
-        fitted_fun, svr_gamma = get_prediction_by_svr(mean, cv, svr_gamma)
-        score = cv - fitted_fun(mean)
-        if sort_inverse:
-            score = -score
+            #Temporary values.
+            #adata.shape[1] == valid_CM.shape[1] = adata.var.shape[0]
+            temp = np.full((adata.shape[1],), 0)
+            mean, cv = np.full((adata.shape[1],1), 0), temp
+            _, svr_gamma = None, temp
+            score = temp
+        else:
+            mean, cv = get_mean_cv(adata, valid_CM, algorithm, winsorize, winsor_perc)
+            fitted_fun, svr_gamma = get_prediction_by_svr(mean, cv, svr_gamma)
+            score = cv - fitted_fun(mean)
+            if sort_inverse:
+                score = -score
 
         # Now we can get "SVR" from get_prediction_by_svr
         key = "velocyto_SVR" if layer == "raw" or layer == "X" else layer + "_velocyto_SVR"

--- a/dynamo/preprocessing/pca.py
+++ b/dynamo/preprocessing/pca.py
@@ -244,7 +244,7 @@ def pca(
         X_data = X_data[:, valid_ind]
 
     if 0 in X_data.shape:
-        main_warning("No genes passed filter, aborting preprocessing.")
+        main_warning("No genes passed filter, ABORTING PCA REDUCTION.")
         if return_all:
             return adata, None, None
         else:

--- a/dynamo/preprocessing/utils.py
+++ b/dynamo/preprocessing/utils.py
@@ -415,6 +415,13 @@ def get_svr_filter(
     valid_idx = np.where(np.isfinite(adata.var.loc[:, score_name]))[0]
 
     valid_table = adata.var.iloc[valid_idx, :]
+    if len(valid_table) == 0:
+        main_warning("No gene with valid svr scores")
+        if return_adata:
+            return adata
+        else:
+            return np.zeros(adata.n_vars, dtype=bool)
+
     nth_score = np.sort(valid_table.loc[:, score_name])[::-1][np.min((n_top_genes - 1, valid_table.shape[0] - 1))]
 
     feature_gene_idx = np.where(valid_table.loc[:, score_name] >= nth_score)[0][:n_top_genes]

--- a/dynamo/tools/growth.py
+++ b/dynamo/tools/growth.py
@@ -133,8 +133,8 @@ def score_cells(
 def cell_growth_rate(
     adata: AnnData,
     group: str,
-    source: str,
-    target: str,
+    source: Optional[str] = None,
+    target: Optional[str] = None,
     L0: float = 0.3,
     L: float = 1.2,
     k: float = 1e-3,
@@ -189,7 +189,7 @@ def cell_growth_rate(
                 f"At least one of your input clone information {clone_column}, {group} "
                 f"is not in your adata .obs attribute."
             )
-        if any(i not in adata.obs[group] for i in all_clone_info[2:]):
+        if any(i not in adata.obs[group].values for i in all_clone_info[2:]):
             raise ValueError(
                 f"At least one of your input source/target information {source}, {target} "
                 f"is not in your adata.obs[{group}] column."


### PR DESCRIPTION
Prevent too-small adata sets from producing errors during prepocessing. 

adata.var being too small may still cause Errors, though the error messages are now more informative. 

Temporary empty values are used in place of regular values due to such values not existing.