### PR TITLE
Debug vectorfield given layer input

### DIFF
--- a/dynamo/vectorfield/topography.py
+++ b/dynamo/vectorfield/topography.py
@@ -1007,6 +1007,7 @@ def VectorField(
             X = np.expm1(X)
         else:
             X = inverse_norm(adata, adata.layers[layer])
+            X = X[:, adata.var_names.get_indexer(valid_genes)]
 
         V = adata[:, valid_genes].layers[velocity_key].copy()
 


### PR DESCRIPTION
Bug description: When `layer` is not `None`, `VectorField` doesn't filter the `X` with `valid_genes`, resulting in the inconsistency in the shape of `X` and `V`. 