### PR TITLE
Debug `is_normalized()` in Markov

### DIFF
--- a/dynamo/tools/Markov.py
+++ b/dynamo/tools/Markov.py
@@ -758,7 +758,7 @@ class MarkovChain:
         Returns:
             True if the matrix is properly normalized.
         """
-        if P is not None:
+        if P is None:
             main_warning("No transition matrix input. Normalization check is skipped.")
             return True
         else:

--- a/dynamo/tools/Markov.py
+++ b/dynamo/tools/Markov.py
@@ -758,7 +758,7 @@ class MarkovChain:
         Returns:
             True if the matrix is properly normalized.
         """
-        if not P:
+        if P is not None:
             main_warning("No transition matrix input. Normalization check is skipped.")
             return True
         else:


### PR DESCRIPTION
Bug description: `not P` checks either `True/False` or `None`, which will raise a bug under some circumstances. `P is None` is the better way to perform the check.