### PR TITLE
Update the input of `minimize()` in `lap_T()`

### DIFF
--- a/dynamo/prediction/least_action_path.py
+++ b/dynamo/prediction/least_action_path.py
@@ -323,7 +323,7 @@ def lap_T(
     def jac(x):
         return action_grad_aux(x, vf_func, jac_func, dim, start=path_0[0], end=path_0[-1], D=D, dt=dt)
 
-    sol_dict = minimize(fun, path_0[1:-1], jac=jac)
+    sol_dict = minimize(fun, path_0[1:-1].flatten(), jac=jac)
     path_sol = reshape_path(sol_dict["x"], dim, start=path_0[0], end=path_0[-1])
 
     # further optimization by varying dt


### PR DESCRIPTION
SciPy 1.11.0 deprecated the multidimensional input, details can be found [here](https://github.com/scipy/scipy/blob/v1.11.4/scipy/optimize/_minimize.py#L532). Thus, we need to flatten the input `x0` first. This is automatically done by `_minimize_bfgs` in the [earlier version](https://github.com/scipy/scipy/blob/52722c24fc08d6241be9c8b40812d301f7b76b24/scipy/optimize/_optimize.py#L1411).