### PR TITLE
Add two tests for selecting transition_genes in tl.cell_velocities

### DIFF
--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -72,6 +72,32 @@ def test_norm_loglikelihood():
     assert ll - ll_ground_truth < 1e-9
 
 
+def setup_cell_velocities_tests():
+    # Sets up adata for test cases
+    # Select only part of data to speed up tests.
+    adata = dyn.sample_data.DentateGyrus_scvelo()[:200, :1000]
+    from dynamo.preprocessing import Preprocessor
+    preprocessor = Preprocessor()
+    preprocessor.preprocess_adata(adata, recipe="monocle")
+    dyn.tl.dynamics(adata, model="stochastic")
+    dyn.tl.reduceDimension(adata)
+    return adata
+
+
+def test_cell_velocities():
+    adata = setup_cell_velocities_tests()
+
+    dyn.tl.cell_velocities(adata)
+    assert 'velocity_S' in adata.layers
+
+
+def test_cell_velocities_selecting_transition_genes():
+    adata = setup_cell_velocities_tests()
+
+    dyn.tl.cell_velocities(adata, transition_genes=[True]*adata.n_vars)
+    assert 'velocity_S' in adata.layers
+
+
 if __name__ == "__main__":
     # test_calc_laplacian()
     # test_divergence()


### PR DESCRIPTION
This PR currently just adds two tests, one were running `tl.cell_velocities` works and one were selecting for `transition_genes` fails. From trying to debug it, I would say that there is some unintended interplay of `dynamics_genes` and `transition_genes` which results in incompatible array shapes in different places.

Furthermore, the documentation of `transition_matrix` in `tl.cell_velocities` seems to be off.