### PR TITLE
Retry codecov upload

### DIFF
--- a/.github/workflows/python-plain-run-test.yml
+++ b/.github/workflows/python-plain-run-test.yml
@@ -44,7 +44,11 @@ jobs:
         pip install pytest-cov
         pytest --cov=./ --cov-report=xml
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: Wandalen/wretry.action@v1
       with:
-        fail_ci_if_error: true
-        verbose: true
+        action: codecov/codecov-action@v3
+        with:
+          fail_ci_if_error: true
+          verbose: true
+        attempt_limit: 5
+        attempt_delay: 10000

--- a/.github/workflows/python-plain-run-test.yml
+++ b/.github/workflows/python-plain-run-test.yml
@@ -47,7 +47,7 @@ jobs:
       uses: Wandalen/wretry.action@v1
       with:
         action: codecov/codecov-action@v3
-        with:
+        with: |
           fail_ci_if_error: true
           verbose: true
         attempt_limit: 5


### PR DESCRIPTION
A retry attempt will reduce the failure count of the code coverage upload problem.