### PR TITLE
Replace `louvain` with `leiden`

### DIFF
--- a/dynamo/tools/clustering.py
+++ b/dynamo/tools/clustering.py
@@ -494,7 +494,7 @@ def cluster_community(
 def cluster_community_from_graph(
     graph=None,
     graph_sparse_matrix: Union[np.ndarray, csr_matrix, None] = None,
-    method: Literal["leiden", "louvain"] = "louvain",
+    method: Literal["leiden", "louvain"] = "leiden",
     directed: bool = False,
     **kwargs
 ) -> Any:

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ seaborn>=0.9.0
 colorcet>=2.0.1
 tqdm
 igraph>=0.7.1
-louvain==0.8.0
+leidenalg
 pynndescent>=0.5.2
 pre-commit
 networkx>=2.6


### PR DESCRIPTION
Replace `louvain` with `leiden` as the default clustering method for its better performance and maintenance.