### PR TITLE
Debug set_figure_params

### DIFF
--- a/dynamo/configuration.py
+++ b/dynamo/configuration.py
@@ -789,14 +789,14 @@ def set_figure_params(
             for more details.
     """
 
-    try:
-        import IPython
+    import builtins
+
+    if getattr(builtins, "__IPYTHON__", False):
+        import matplotlib_inline.backend_inline
 
         if isinstance(ipython_format, str):
             ipython_format = [ipython_format]
-        IPython.display.set_matplotlib_formats(*ipython_format)
-    except Exception:
-        pass
+        matplotlib_inline.backend_inline.set_matplotlib_formats(*ipython_format)
 
     from matplotlib import rcParams
 

--- a/dynamo/configuration.py
+++ b/dynamo/configuration.py
@@ -792,11 +792,14 @@ def set_figure_params(
     import builtins
 
     if getattr(builtins, "__IPYTHON__", False):
-        import matplotlib_inline.backend_inline
+        try:
+            import matplotlib_inline.backend_inline
 
-        if isinstance(ipython_format, str):
-            ipython_format = [ipython_format]
-        matplotlib_inline.backend_inline.set_matplotlib_formats(*ipython_format)
+            if isinstance(ipython_format, str):
+                ipython_format = [ipython_format]
+            matplotlib_inline.backend_inline.set_matplotlib_formats(*ipython_format)
+        except Exception:
+            pass
 
     from matplotlib import rcParams
 


### PR DESCRIPTION
Set `matplotlib` formats directly with `matplotlib` since`set_matplotlib_formats` is [deprecated](https://ipython.readthedocs.io/en/stable/api/generated/IPython.display.html#IPython.display.set_matplotlib_formats) in the earlier version of IPython. 