### PR TITLE
Add temporary anndata version constraint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ numpy>=1.20.0,<2.0.0
 pandas>=1.3.5
 scipy>=1.4.1
 scikit-learn>=0.19.1,<1.5.0
-anndata>=0.8.0
+anndata>=0.8.0,<0.11.0
 loompy>=3.0.5
 matplotlib>=3.7.5
 setuptools


### PR DESCRIPTION
Updates in newer anndata versions break compatibility with dynamo, causing CI/CD workflow failures. Added version constraint as a temporary workaround until compatibility is restored.