### PR TITLE
Added Dynamo's skills for PantheonOS/Claude/Codex

### DIFF
--- a/dynamo/plot/pseudotime.py
+++ b/dynamo/plot/pseudotime.py
@@ -20,6 +20,7 @@ def _calculate_cells_mapping(
     adata: AnnData,
     group_key: str,
     cell_proj_closest_vertex: Optional[np.ndarray] = None,
+    n_nodes: Optional[int] = None,
 ) -> Tuple[np.ndarray, np.ndarray, Dict]:
     """Calculate the distribution of cells in each node.
 
@@ -27,11 +28,12 @@ def _calculate_cells_mapping(
         adata: the anndata object.
         group_key: the key to locate the groups of each cell in adata.
         cell_proj_closest_vertex: the mapping from each cell to the corresponding node.
+        n_nodes: the total number of nodes in the graph. Used to ensure nodes with no mapped cells are included.
 
     Returns:
         The size of each node, the percentage of each group in every node, and the color mapping of each group.
     """
-    cells_mapping_size = np.bincount(cell_proj_closest_vertex)
+    cells_mapping_size = np.bincount(cell_proj_closest_vertex, minlength=n_nodes if n_nodes is not None else 0)
     centroids_index = range(len(cells_mapping_size))
 
     cell_type_info = pd.DataFrame(
@@ -111,10 +113,12 @@ def plot_dim_reduced_direct_graph(
     except KeyError:
         raise KeyError("Cell order data is missing. Please run `tl.order_cells()` first!")
 
+    n_nodes = graph.shape[0]
     cells_size, cells_percentage, cells_color_map = _calculate_cells_mapping(
         adata=adata,
         group_key=group_key,
         cell_proj_closest_vertex=cell_proj_closest_vertex,
+        n_nodes=n_nodes,
     )
 
     cells_colors = np.array([v for v in cells_color_map.values()])

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,0 +1,70 @@
+{% set name = "dynamo-release" %}
+{% set version = "1.5.2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/aristoteleo/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: ff85e911b5b8c5269d18777d64d7c497165e3aadc895620c8166051a429ddfb9
+
+build:
+  script: {{ PYTHON }} -m pip install . -vv
+  number: 0
+  noarch: python
+
+requirements:
+  host:
+    - python >=3.9
+    - setuptools
+    - pip
+  run:
+    - python >=3.9
+    - setuptools
+    - numpy >=1.20.0
+    - pandas >=1.3.5,<3.0.0
+    - scipy >=1.4.1
+    - scikit-learn >=0.19.1
+    - anndata >=0.8.0,<0.11.0
+    - loompy >=3.0.5
+    - matplotlib-base >=3.7.5
+    - numdifftools >=0.9.39
+    - umap-learn >=0.5.1
+    - patsy >=0.5.1
+    - statsmodels >=0.9.0
+    - numba >=0.54.0
+    - seaborn >=0.9.0
+    - colorcet >=2.0.1
+    - tqdm
+    - igraph >=0.7.1
+    - leidenalg
+    - pynndescent >=0.5.2
+    - networkx >=2.6
+    - get_version >=3.5.4
+    - typing-extensions
+    - openpyxl
+    - session-info >=1.0.0
+    - adjusttext
+    - mudata
+    - requests
+    - datacache
+
+test:
+  imports:
+    - dynamo
+  requires:
+    - pip
+
+about:
+  home: https://github.com/aristoteleo/dynamo-release
+  summary: 'Inclusive model of expression dynamics with metabolic labeling based scRNA-seq'
+  description: |
+    Inclusive model of expression dynamics with metabolic labeling based scRNA-seq in silico perturbation predictions.
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - Xiaojieqiu

--- a/skills/dynamo-conventional-rna-velocity/SKILL.md
+++ b/skills/dynamo-conventional-rna-velocity/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: dynamo-conventional-rna-velocity
+description: Run or adapt a conventional spliced/unspliced RNA velocity workflow in `dynamo`, including `Preprocessor` preprocessing, `dynamics`, low-dimensional `cell_velocities`, `VectorField`, topology / potential analysis, confidence-based correction, fate prediction, and optional animation. Use when analyzing conventional scRNA-seq `AnnData`, reproducing or adapting tutorial notebooks such as `200_zebrafish.ipynb`, or selecting between preprocessing, kinetics, vector-field, and fate stages for a reusable velocity pipeline.
+---
+
+# Dynamo Conventional RNA Velocity
+
+## Goal
+
+Run the reusable execution spine for conventional spliced / unspliced `dynamo` analysis: preprocess a compatible `AnnData`, estimate velocities with the current `dynamics` API, project them to a low-dimensional basis, reconstruct a vector field, then optionally branch into confidence diagnostics, topology / potential, PCA vector calculus, or fate animation without treating any one notebook or dataset as the workflow identity.
+
+## Quick Workflow
+
+1. Load a conventional spliced / unspliced dataset, make cell names unique, and confirm the grouping column you want to use for interpretation.
+2. Preprocess with `Preprocessor.preprocess_adata(..., recipe='monocle')` unless the user explicitly wants another `recipe`.
+3. Estimate kinetics with `dyn.tl.dynamics(...)`, using `model='stochastic'` by default for conventional velocity analysis unless speed or legacy reproduction requires another branch.
+4. Run `dyn.tl.reduceDimension(...)`, then `dyn.tl.cell_velocities(...)` on the basis the user actually needs.
+5. Reconstruct a vector field with `dyn.vf.VectorField(...)`, then choose one of the downstream branches:
+   confidence / correction, topology / potential, PCA vector calculus, or fate prediction.
+6. Treat animation and styling cells as optional presentation steps after the analytical outputs already exist.
+
+## Interface Summary
+
+- `Preprocessor.preprocess_adata(adata, recipe='monocle', tkey=None, experiment_type=None)` is the preprocessing wrapper.
+- `dyn.tl.dynamics(...)` is the core kinetics and raw-velocity entrypoint.
+- `dyn.tl.cell_velocities(..., basis='umap', method='pearson')` projects high-dimensional velocity to a low-dimensional basis and stores a kernel-specific transition matrix.
+- `dyn.vf.VectorField(..., basis='umap' | 'pca', method='SparseVFC', pot_curl_div=False, **kwargs)` reconstructs the vector field.
+- `dyn.pd.fate(..., direction='both', average=False, inverse_transform=False)` integrates trajectories from chosen initial cells.
+- `dyn.mv.animate_fates(...)` and `dyn.mv.StreamFuncAnim(...)` are optional post-fate animation entrypoints, not core analysis prerequisites.
+
+Read `references/source-grounding.md` before documenting parameter behavior more narrowly than the live source does.
+
+## Stage Selection
+
+- Use the full notebook spine only when the user wants an end-to-end tutorial reproduction.
+- Stop after `dynamics` if the goal is only gene-wise kinetics or phase portraits.
+- Stop after `cell_velocities` if the goal is low-dimensional velocity visualization.
+- Use `VectorField(..., basis='umap')` for topology, potential, and fate visualization in the same embedding used for plots.
+- Use `cell_velocities(..., basis='pca')` plus `VectorField(..., basis='pca')` for speed, divergence, acceleration, and curvature.
+- Use `gene_wise_confidence`, `cell_wise_confidence`, and `confident_cell_velocities` only when the user is debugging suspect flow directions or wants lineage-prior correction.
+
+Read `references/stage-selection.md` before choosing non-default `model`, `method`, `basis`, or `direction` branches.
+
+## Input Contract
+
+- Expect a conventional scRNA-seq `AnnData` with usable `spliced` and `unspliced` layers.
+- Expect to compute a fresh low-dimensional basis unless the user already provides a validated embedding.
+- Expect any grouping column, lineage hints, and marker genes to be dataset-specific inputs, not universal defaults.
+- Treat zebrafish tutorial labels such as `Cell_type`, `Proliferating Progenitor`, and `Schwann Cell` as worked examples only.
+
+## Minimal Execution Patterns
+
+For the default conventional spliced / unspliced workflow:
+
+```python
+import dynamo as dyn
+
+adata = ...  # Any conventional AnnData with spliced/unspliced layers
+adata.obs_names_make_unique()
+
+preprocessor = dyn.pp.Preprocessor(cell_cycle_score_enable=False)
+preprocessor.preprocess_adata(adata, recipe="monocle")
+
+dyn.tl.dynamics(adata, model="stochastic", cores=1)
+dyn.tl.reduceDimension(adata)
+dyn.tl.cell_velocities(adata, basis="umap", method="pearson")
+dyn.vf.VectorField(adata, basis="umap", M=1000, pot_curl_div=False)
+```
+
+For the worked example notebook path:
+
+```python
+adata = dyn.sample_data.zebrafish()
+adata.obs_names_make_unique()
+```
+
+For confidence-based correction after the initial velocity run:
+
+```python
+dyn.tl.gene_wise_confidence(
+    adata,
+    group=group_key,
+    lineage_dict=lineage_dict,
+)
+dyn.tl.cell_wise_confidence(adata, method="jaccard")
+dyn.tl.confident_cell_velocities(
+    adata,
+    group=group_key,
+    lineage_dict=lineage_dict,
+)
+```
+
+For the zebrafish worked example only:
+
+```python
+group_key = "Cell_type"
+lineage_dict = {"Proliferating Progenitor": ["Schwann Cell"]}
+```
+
+For topology / potential on UMAP:
+
+```python
+dyn.vf.VectorField(adata, basis="umap", M=1000, pot_curl_div=True)
+# This populates keys such as:
+# adata.obs["umap_ddhodge_potential"], adata.obs["curl_umap"], adata.obs["divergence_umap"]
+```
+
+For PCA vector calculus:
+
+```python
+dyn.tl.cell_velocities(adata, basis="pca", method="pearson")
+dyn.vf.VectorField(adata, basis="pca")
+dyn.vf.speed(adata, basis="pca")
+dyn.vf.divergence(adata, basis="pca")
+dyn.vf.acceleration(adata, basis="pca")
+dyn.vf.curvature(adata, basis="pca")
+```
+
+For forward fate prediction from a dataset-specific progenitor selection:
+
+```python
+init_cells = adata.obs_names[adata.obs[group_key].isin(progenitor_labels)]
+
+dyn.pd.fate(
+    adata,
+    basis="umap",
+    init_cells=init_cells[:20],
+    interpolation_num=100,
+    direction="forward",
+    inverse_transform=False,
+    average=False,
+    cores=1,
+)
+```
+
+For the zebrafish worked example only:
+
+```python
+group_key = "Cell_type"
+progenitor_labels = ["Proliferating Progenitor", "Pigment Progenitor"]
+```
+
+## Validation
+
+After preprocessing, check these items:
+
+- `adata.uns["pp"]["experiment_type"] == "conventional"` for the chosen dataset.
+- `adata.obsm["X_pca"]` exists.
+- `adata.var["use_for_pca"]` exists.
+
+After `dynamics`, check these items:
+
+- `adata.uns["dynamics"]["model"]` matches the chosen branch.
+- `adata.uns["dynamics"]["experiment_type"] == "conventional"` on conventional data.
+- `adata.layers["velocity_S"]` exists.
+- `adata.var["use_for_dynamics"]` exists.
+
+After `cell_velocities(..., method="pearson")`, check these items:
+
+- `adata.obsm["velocity_umap"]` exists for the UMAP branch.
+- the transition matrix is stored under the kernel-specific key `adata.obsp["pearson_transition_matrix"]`, not a generic `transition_matrix`.
+
+After `VectorField(..., basis="umap")`, check these items:
+
+- `adata.uns["VecFld_umap"]` exists.
+- `adata.obs["obs_vf_angle_umap"]` exists.
+
+After `VectorField(..., pot_curl_div=True)`, check these items:
+
+- `adata.obs["umap_ddhodge_potential"]` exists.
+- `adata.obs["curl_umap"]` and `adata.obs["divergence_umap"]` exist.
+
+After `pd.fate(..., basis="umap")`, check these items:
+
+- `adata.uns["fate_umap"]` exists.
+- `adata.uns["fate_umap"]["t"]` and `adata.uns["fate_umap"]["prediction"]` are populated.
+
+## Constraints
+
+- Do not assume any tutorial dataset already has `adata.obsm["X_umap"]`; compute or validate the embedding before downstream UMAP-specific steps.
+- Do not assume observation names are unique on load; call `adata.obs_names_make_unique()` before branching deeper into the workflow.
+- Do not copy zebrafish-specific grouping columns, lineage labels, or marker genes into a different dataset without replacing them.
+- Do not treat every notebook plot as analytically required. Most styling, save / reload, and presentation cells are optional.
+- Do not document `VectorField(..., M=1000)` as if it were in the public signature; `M` is passed through `**kwargs` into SparseVFC defaults.
+- Prefer `method='pearson'` only for notebook parity. Other `cell_velocities` kernels are real source-level branches and should not be silently omitted.
+
+## Resource Map
+
+- Read `references/stage-selection.md` for branch-by-branch defaults and decision rules.
+- Read `references/source-grounding.md` for inspected signatures, source-level branch evidence, and empirical execution notes.
+- Read `references/visualization-and-animation.md` when the user specifically wants `topography`, `StreamFuncAnim`, `animate_fates`, or `animate_streamplot`.
+- Read `references/source-notebook-map.md` to trace `200_zebrafish.ipynb` into the generic velocity skill and its worked-example sections.
+- Read `references/compatibility.md` when notebook wording and current source behavior appear to disagree.

--- a/skills/dynamo-conventional-rna-velocity/assets/acceptance.json
+++ b/skills/dynamo-conventional-rna-velocity/assets/acceptance.json
@@ -1,0 +1,76 @@
+{
+  "version": 1,
+  "skill": "dynamo-conventional-rna-velocity",
+  "sample_requests": [
+    "Run a conventional spliced/unspliced dynamo RNA velocity workflow through vector field and fate prediction",
+    "Adapt the 200_zebrafish tutorial to my conventional scRNA-seq AnnData without hard-coding zebrafish-specific labels"
+  ],
+  "required_description_terms": [
+    "dynamo",
+    "conventional",
+    "spliced/unspliced",
+    "preprocessor",
+    "dynamics",
+    "vectorfield",
+    "fate",
+    "tutorial"
+  ],
+  "required_sections": [
+    "## Goal",
+    "## Quick Workflow",
+    "## Interface Summary",
+    "## Stage Selection",
+    "## Validation",
+    "## Resource Map"
+  ],
+  "required_body_terms": [
+    "dynamics",
+    "cell_velocities",
+    "vectorfield",
+    "pearson_transition_matrix",
+    "velocity_umap",
+    "vecfld_umap",
+    "umap_ddhodge_potential",
+    "fate_umap",
+    "animate_fates",
+    "group_key",
+    "lineage_dict"
+  ],
+  "required_paths": [
+    "references/stage-selection.md",
+    "references/source-grounding.md",
+    "references/visualization-and-animation.md",
+    "references/source-notebook-map.md",
+    "references/compatibility.md"
+  ],
+  "smoke_commands": [
+    {
+      "name": "umap-core-and-fate",
+      "conda_env": "omictest",
+      "env": {
+        "PYTHONPATH": ".",
+        "MPLCONFIGDIR": "/tmp/mpl",
+        "NUMBA_CACHE_DIR": "/tmp/numba"
+      },
+      "command": "${PYTHON} -c \"import dynamo as dyn; adata = dyn.sample_data.zebrafish()[:300].copy(); adata.obs_names_make_unique(); p = dyn.pp.Preprocessor(cell_cycle_score_enable=False); p.preprocess_adata(adata, recipe='monocle'); dyn.tl.dynamics(adata, model='stochastic', cores=1); dyn.tl.reduceDimension(adata); dyn.tl.cell_velocities(adata, basis='umap', method='pearson'); dyn.vf.VectorField(adata, basis='umap', M=100, pot_curl_div=False); progenitor = adata.obs_names[adata.obs.Cell_type.isin(['Proliferating Progenitor', 'Pigment Progenitor'])][:20]; dyn.pd.fate(adata, basis='umap', init_cells=progenitor, interpolation_num=20, direction='forward', inverse_transform=False, average=False, cores=1); print('velocity_umap' in adata.obsm, 'pearson_transition_matrix' in adata.obsp, 'VecFld_umap' in adata.uns, 'fate_umap' in adata.uns)\"",
+      "timeout_seconds": 240,
+      "expect_stdout_contains": [
+        "True True True True"
+      ]
+    },
+    {
+      "name": "topology-potential-branch",
+      "conda_env": "omictest",
+      "env": {
+        "PYTHONPATH": ".",
+        "MPLCONFIGDIR": "/tmp/mpl",
+        "NUMBA_CACHE_DIR": "/tmp/numba"
+      },
+      "command": "${PYTHON} -c \"import dynamo as dyn; adata = dyn.sample_data.zebrafish()[:200].copy(); adata.obs_names_make_unique(); p = dyn.pp.Preprocessor(cell_cycle_score_enable=False); p.preprocess_adata(adata, recipe='monocle'); dyn.tl.dynamics(adata, model='stochastic', cores=1); dyn.tl.reduceDimension(adata); dyn.tl.cell_velocities(adata, basis='umap', method='pearson'); dyn.vf.VectorField(adata, basis='umap', M=100, pot_curl_div=True, cores=1); print('umap_ddhodge_potential' in adata.obs, 'curl_umap' in adata.obs, 'divergence_umap' in adata.obs)\"",
+      "timeout_seconds": 240,
+      "expect_stdout_contains": [
+        "True True True"
+      ]
+    }
+  ]
+}

--- a/skills/dynamo-conventional-rna-velocity/references/compatibility.md
+++ b/skills/dynamo-conventional-rna-velocity/references/compatibility.md
@@ -1,0 +1,70 @@
+# Compatibility
+
+Use this reference when notebook wording and current source behavior differ.
+
+Scope rule:
+
+- zebrafish-specific details here are compatibility notes for the worked example dataset
+- they are not universal assumptions for every conventional spliced/unspliced input
+
+## Sample Data Shape
+
+Observed on current `dyn.sample_data.zebrafish()` worked example:
+
+- raw dataset includes `spliced` and `unspliced` layers
+- raw dataset includes `Cell_type` in `.obs`
+- raw dataset does not include `obsm["X_umap"]`
+- observation names are not unique
+
+Conservative rule:
+
+- run `adata.obs_names_make_unique()` immediately after loading
+- run `dyn.tl.reduceDimension(...)` before expecting `X_umap`
+- do not generalize zebrafish sample metadata layout to unrelated datasets
+
+## Transition Matrix Storage
+
+Notebook prose treats the transition matrix generically.
+
+Observed current behavior for `method='pearson'`:
+
+- velocity projection key: `adata.obsm["velocity_umap"]`
+- transition matrix key: `adata.obsp["pearson_transition_matrix"]`
+
+Conservative rule:
+
+- do not hard-code `transition_matrix` unless the code path actually created that key
+
+## `VectorField(..., M=1000)`
+
+The notebook passes `M=1000`.
+
+Observed current source behavior:
+
+- `VectorField` accepts this via `**kwargs`
+- SparseVFC defaults are set in `_get_svc_default_arguments(...)`
+- `M` defaults to `None` there
+
+Conservative rule:
+
+- document `M` as a pass-through SparseVFC tuning knob, not a top-level public parameter
+
+## Potential / Topology Path
+
+Observed current behavior:
+
+- `pot_curl_div=True` on a 2D basis computes ddHodge potential, curl, and divergence automatically
+
+Conservative rule:
+
+- prefer this compact path over manually assuming that plotting functions themselves compute all prerequisites
+
+## Animation Tooling
+
+Observed current behavior:
+
+- `animate_fates(..., save_show_or_return='save')` may require `imagemagick`
+
+Conservative rule:
+
+- keep animation optional and do not make it a validation prerequisite for the main analytical workflow

--- a/skills/dynamo-conventional-rna-velocity/references/source-grounding.md
+++ b/skills/dynamo-conventional-rna-velocity/references/source-grounding.md
@@ -1,0 +1,189 @@
+# Source Grounding
+
+This skill was generated from live code inspection and empirical execution on the zebrafish worked example, not from notebook prose alone.
+
+## Inspection Notes
+
+Source inspection and empirical checks were performed in a local Python runtime compatible with this repository's dependencies.
+
+## Primary Source Files
+
+Notebook inspected:
+
+- `docs/tutorials/notebooks/200_zebrafish.ipynb`
+
+Code inspected:
+
+- `dynamo/preprocessing/Preprocessor.py`
+- `dynamo/tools/dynamics.py`
+- `dynamo/tools/cell_velocities.py`
+- `dynamo/vectorfield/VectorField.py`
+- `dynamo/prediction/fate.py`
+- `dynamo/movie/fate.py`
+- `dynamo/plot/topography.py`
+- `dynamo/plot/animation_lines.py`
+
+## Inspected Interfaces
+
+### `Preprocessor.preprocess_adata`
+
+Observed signature:
+
+```python
+(self, adata, recipe='monocle', tkey=None, experiment_type=None) -> None
+```
+
+Observed `recipe` branches in current source:
+
+- `monocle`
+- `seurat`
+- `sctransform`
+- `pearson_residuals`
+- `monocle_pearson_residuals`
+
+### `dyn.tl.dynamics`
+
+Observed signature includes these branch-heavy parameters:
+
+- `model`: `auto`, `deterministic`, `stochastic`
+- `est_method`: `ols`, `rlm`, `ransac`, `gmm`, `negbin`, `auto`, `twostep`, `direct`
+- `one_shot_method`: `combined`, `sci-fate`, `sci_fate`
+
+Observed runtime on the zebrafish worked example after preprocessing:
+
+- `experiment_type='conventional'`
+- `model='stochastic'`
+- `est_method='gmm'`
+- `has_splicing=True`
+- `has_labeling=False`
+
+### `dyn.tl.cell_velocities`
+
+Observed signature:
+
+```python
+(..., basis='umap', method='pearson', ...) -> AnnData
+```
+
+Observed `method` branches:
+
+- `kmc`
+- `fp`
+- `cosine`
+- `pearson`
+- `transform`
+
+Notebook-important runtime finding:
+
+- after `method='pearson'`, the projected velocity is written to `adata.obsm["velocity_umap"]`
+- the transition matrix is written to `adata.obsp["pearson_transition_matrix"]`
+- there is no generic `adata.obsp["transition_matrix"]` in this branch by default
+
+### `dyn.vf.VectorField`
+
+Observed signature:
+
+```python
+(adata, basis=None, layer=None, ..., method='SparseVFC', pot_curl_div=False, **kwargs)
+```
+
+Observed `method` branches:
+
+- `SparseVFC`
+- `dynode`
+
+Important source detail:
+
+- notebook argument `M=1000` is not part of the public signature
+- current source forwards `M` through `**kwargs`
+- SparseVFC defaults are assembled in `_get_svc_default_arguments(...)`, where `M` defaults to `None`
+
+Observed `pot_curl_div=True` behavior:
+
+- runs `ddhodge(adata, basis=basis, cores=cores)`
+- computes curl automatically for 2D bases
+- computes divergence automatically
+
+### `dyn.pd.fate`
+
+Observed signature includes these branch-heavy parameters:
+
+- `direction`: `forward`, `backward`, `both`
+- `average`: `False`, `True`, `origin`, `trajectory`
+- `sampling`: `arc_length`, `logspace`, `uniform_indices`
+- `inverse_transform`: `False`, `True`
+
+Observed runtime:
+
+- `basis='umap'`, `direction='forward'`, `average=False` stores results under `adata.uns["fate_umap"]`
+
+### Visualization / Animation Entry Points
+
+Observed signatures:
+
+- `dyn.pl.topography(...)`
+- `dyn.mv.StreamFuncAnim(...)`
+- `dyn.mv.animate_fates(...)`
+- `dyn.pl.compute_velocity_on_grid(...)`
+- `dyn.pl.animate_streamplot(...)`
+
+Important preconditions:
+
+- `animate_fates` expects prior `fate(...)` output
+- `animate_streamplot` operates on precomputed `X_grid`, `V_grid`
+
+## Empirical Checks Run
+
+### Sample Data Load
+
+Observed on the current zebrafish worked example:
+
+- dataset downloads to `./data/zebrafish.h5ad` on first use
+- shape is `4181 x 16940`
+- raw sample contains `layers["spliced"]`, `layers["unspliced"]`
+- raw sample exposes `Cell_type` in `.obs`
+- raw sample does not expose `obsm["X_umap"]`
+- observation names are not unique until fixed
+
+Worked-example note:
+
+- these metadata names are useful for reproducing `200_zebrafish.ipynb`
+- they are not part of the generic input contract for the skill
+
+### Core UMAP Workflow
+
+Checked on a `300`-cell subset:
+
+1. `obs_names_make_unique()`
+2. `preprocess_adata(..., recipe='monocle')`
+3. `dynamics(..., model='stochastic', cores=1)`
+4. `reduceDimension(...)`
+5. `cell_velocities(..., method='pearson')`
+6. `VectorField(..., basis='umap', M=100, pot_curl_div=False)`
+7. `fate(..., basis='umap', direction='forward', average=False, inverse_transform=False)`
+
+Observed outputs:
+
+- `X_pca`
+- `velocity_S`
+- `X_umap`
+- `velocity_umap`
+- `pearson_transition_matrix`
+- `VecFld_umap`
+- `fate_umap`
+
+### Topology / Potential Branch
+
+Checked on a `200`-cell subset with `pot_curl_div=True`:
+
+Observed outputs:
+
+- `adata.obs["umap_ddhodge_potential"]`
+- `adata.obs["curl_umap"]`
+- `adata.obs["divergence_umap"]`
+- `adata.uns["VecFld_umap"]`
+
+## Human Review Notes
+
+- The notebook is end-to-end, but the stable reusable job is stage-based, not “run every cell”.
+- The strongest compatibility traps here are data-shape assumptions, basis-dependent outputs, and kernel-specific storage names, not just method defaults.

--- a/skills/dynamo-conventional-rna-velocity/references/source-notebook-map.md
+++ b/skills/dynamo-conventional-rna-velocity/references/source-notebook-map.md
@@ -1,0 +1,151 @@
+# Source Notebook Map
+
+Source notebook:
+`docs/tutorials/notebooks/200_zebrafish.ipynb`
+
+Use this file to see how the notebook was converted into a reusable stage-based skill.
+
+Conversion rule used here:
+
+- the stable skill identity is conventional spliced/unspliced RNA velocity in `dynamo`
+- zebrafish remains the worked example notebook, not the trigger surface
+
+## Notebook Sections To Skill Responsibilities
+
+### 1. Setup and sample-data loading
+
+Notebook role:
+
+- install / import `dynamo`
+- set plotting style
+- load `dyn.sample_data.zebrafish()`
+
+Preserved in the skill:
+
+- `SKILL.md` Quick Workflow
+- `SKILL.md` Input Contract
+- `references/source-grounding.md`
+- `references/compatibility.md`
+
+Intentionally dropped:
+
+- notebook magics
+- presentation styling
+- inline package-upgrade cell
+
+### 2. Preprocessing
+
+Notebook role:
+
+- run the monocle preprocessing path on conventional spliced / unspliced data
+
+Preserved in the skill:
+
+- `SKILL.md` Stage Selection
+- `SKILL.md` Minimal Execution Patterns
+- `references/stage-selection.md`
+
+Source-grounded addition:
+
+- current `recipe` branch set includes more than the notebook’s single visible path
+
+### 3. Kinetics and low-dimensional velocity
+
+Notebook role:
+
+- run `dynamics(model='stochastic')`
+- compute UMAP
+- project velocity with `cell_velocities(method='pearson')`
+
+Preserved in the skill:
+
+- `SKILL.md` Minimal Execution Patterns
+- `SKILL.md` Validation
+- `references/stage-selection.md`
+
+Source-grounded addition:
+
+- `cell_velocities` supports multiple kernel methods beyond the single notebook call
+- transition matrix storage is kernel-specific
+
+### 4. Confidence diagnostics and correction
+
+Notebook role:
+
+- inspect gene-wise and cell-wise confidence
+- optionally reproject confident cell velocities using lineage priors
+
+Preserved in the skill:
+
+- `SKILL.md` Stage Selection
+- `SKILL.md` Minimal Execution Patterns
+- `references/stage-selection.md`
+
+Worked-example downgrade:
+
+- zebrafish lineage labels remain as a worked example only
+- generic `group_key` and `lineage_dict` are the main reusable interface
+
+### 5. Vector field, topology, and potential
+
+Notebook role:
+
+- reconstruct UMAP vector field
+- inspect fixed points and topology
+- use ddHodge potential as pseudotime-like ordering
+
+Preserved in the skill:
+
+- `SKILL.md` Minimal Execution Patterns
+- `references/visualization-and-animation.md`
+
+Worked-example downgrade:
+
+- zebrafish progenitor labels remain only as an example selection
+- the reusable interface uses dataset-specific `progenitor_labels`
+- `references/source-grounding.md`
+
+Source-grounded addition:
+
+- `pot_curl_div=True` is the compact executable route to the notebook’s potential / curl / divergence stage
+
+### 6. PCA vector calculus
+
+Notebook role:
+
+- switch to PCA basis
+- compute speed, curl, divergence, acceleration, curvature
+
+Preserved in the skill:
+
+- `SKILL.md` Stage Selection
+- `SKILL.md` Minimal Execution Patterns
+- `references/stage-selection.md`
+
+### 7. Fate prediction and animation
+
+Notebook role:
+
+- select progenitors
+- run `pd.fate`
+- animate with `StreamFuncAnim`, `animate_fates`, and a streamplot GIF path
+
+Preserved in the skill:
+
+- `SKILL.md` Minimal Execution Patterns
+- `references/visualization-and-animation.md`
+
+## What Was Intentionally Not Carried Over
+
+- extensive biological interpretation prose
+- figure-by-figure walkthrough text
+- repeated save / reload cells
+- notebook-only HTML / JS embedding cells
+
+## When To Reopen The Notebook
+
+Reopen the notebook only when:
+
+- the user wants figure parity or presentation styling
+- the user wants the exact published gene panels and story-line interpretation
+- a future notebook revision changes the demonstrated stage order or branch choices

--- a/skills/dynamo-conventional-rna-velocity/references/stage-selection.md
+++ b/skills/dynamo-conventional-rna-velocity/references/stage-selection.md
@@ -1,0 +1,149 @@
+# Stage Selection
+
+This notebook mixes preprocessing, kinetics, projection, vector-field analysis, topology, differential geometry, and animation. Use this reference to keep those stages separate instead of blindly replaying all cells or overfitting the skill to the zebrafish sample.
+
+## Default Job
+
+If the user asks to run a conventional spliced/unspliced `dynamo` velocity workflow:
+
+1. preprocess with `recipe='monocle'`
+2. run `dyn.tl.dynamics(..., model='stochastic')`
+3. run `dyn.tl.reduceDimension(...)`
+4. run `dyn.tl.cell_velocities(..., basis='umap', method='pearson')`
+5. run `dyn.vf.VectorField(..., basis='umap')`
+
+Only add later stages if the user’s goal needs them.
+
+## Stage 1: Preprocessing
+
+Current source branches for `Preprocessor.preprocess_adata(...)`:
+
+- `monocle`
+- `seurat`
+- `sctransform`
+- `pearson_residuals`
+- `monocle_pearson_residuals`
+
+Recommendation for this workflow family:
+
+- use `monocle` by default
+
+Reason:
+
+- the tutorial is conventional spliced / unspliced scRNA-seq
+- downstream velocity and vector-field analysis rely on the monocle-style normalized layers and PCA path
+
+## Stage 2: Kinetics With `dyn.tl.dynamics`
+
+Relevant branch-heavy parameters:
+
+- `model`: `auto`, `deterministic`, `stochastic`
+- `est_method`: `ols`, `rlm`, `ransac`, `gmm`, `negbin`, `auto`, `twostep`, `direct`
+- `one_shot_method`: `combined`, `sci-fate`, `sci_fate`
+
+Recommendation for this workflow family:
+
+- use `model='stochastic'`
+- let `est_method='auto'` resolve unless the user explicitly asks otherwise
+
+Observed runtime result on the zebrafish worked example:
+
+- `experiment_type='conventional'`
+- `model='stochastic'`
+- `est_method='gmm'`
+
+When to switch:
+
+- use `model='deterministic'` for faster legacy-style RNA velocity parity
+- use `est_method='negbin'` only if the user explicitly wants that steady-state branch
+
+## Stage 3: Velocity Projection
+
+Relevant branch-heavy parameters on `dyn.tl.cell_velocities(...)`:
+
+- `basis`
+- `method`: `kmc`, `fp`, `cosine`, `pearson`, `transform`
+
+Recommendation for this workflow family:
+
+- use `basis='umap'`, `method='pearson'` for notebook parity
+
+When to switch:
+
+- use `method='kmc'` if the user wants the newer Itô-kernel style projection
+- use `method='cosine'` for closer legacy velocyto-style behavior
+- avoid `method='transform'` unless the user explicitly wants UMAP-transform projection and accepts the warning that it is not recommended
+- use `basis='pca'` for the later vector-calculus stage
+
+Important storage rule:
+
+- the transition matrix key is kernel-specific, for example `pearson_transition_matrix`
+
+## Stage 4: Vector Field
+
+Relevant branch-heavy parameters on `dyn.vf.VectorField(...)`:
+
+- `basis`
+- `method`: `SparseVFC`, `dynode`
+- `pot_curl_div`: `False` / `True`
+
+Recommendation for this workflow family:
+
+- use `basis='umap'`, `method='SparseVFC'`
+
+When to switch:
+
+- use `basis='pca'` for speed / divergence / acceleration / curvature
+- use `pot_curl_div=True` when the user wants potential, curl, or divergence keys added automatically
+- use `method='dynode'` only if the environment has `dynode` and the user explicitly wants that branch
+
+About `M`:
+
+- the notebook uses `M=1000`
+- current source passes `M` through `**kwargs` into SparseVFC defaults where its default is `None`
+
+## Stage 5: Confidence And Correction
+
+Relevant branch-heavy parameter:
+
+- `dyn.tl.cell_wise_confidence(..., method=...)`
+
+Current signature values:
+
+- `cosine`
+- `consensus`
+- `correlation`
+- `jaccard`
+- `hybrid`
+- `divergence`
+
+Recommendation for this workflow family:
+
+- start with `jaccard`
+- use `gene_wise_confidence(...)` and `confident_cell_velocities(...)` only when debugging suspicious flow directions or applying lineage priors
+
+## Stage 6: Fate Prediction
+
+Relevant branch-heavy parameters on `dyn.pd.fate(...)`:
+
+- `direction`: `forward`, `backward`, `both`
+- `average`: `False`, `True`, `origin`, `trajectory`
+- `sampling`: `arc_length`, `logspace`, `uniform_indices`
+- `inverse_transform`: `False` / `True`
+
+Recommendation for this workflow family:
+
+- use `basis='umap'`
+- use `direction='forward'`
+- use `average=False`
+- use `inverse_transform=False`
+- keep `sampling='arc_length'` unless the user explicitly wants another path
+
+## Decision Rule
+
+If the user asks for:
+
+- "the notebook result" -> run the default job through UMAP vector field, then apply the notebook's dataset-specific labels as a worked example
+- "potential" or "fixed points" -> add `pot_curl_div=True` and `topography`
+- "speed / acceleration / curvature" -> switch to the PCA vector-calculus stage
+- "animation" -> run `fate` first, then animation entrypoints

--- a/skills/dynamo-conventional-rna-velocity/references/visualization-and-animation.md
+++ b/skills/dynamo-conventional-rna-velocity/references/visualization-and-animation.md
@@ -1,0 +1,98 @@
+# Visualization And Animation
+
+Use this reference only when the user explicitly wants notebook-style plots, topology visuals, or animations.
+
+## Topography
+
+Primary entrypoint:
+
+- `dyn.pl.topography(...)`
+
+Recommended prerequisites:
+
+1. `dyn.tl.reduceDimension(...)`
+2. `dyn.tl.cell_velocities(..., basis='umap')`
+3. `dyn.vf.VectorField(..., basis='umap', pot_curl_div=True)`
+
+Why:
+
+- topography depends on the learned vector field and is most natural on a 2D basis such as UMAP
+- `pot_curl_div=True` precomputes potential, curl, and divergence keys used throughout the notebook interpretation
+
+Notebook-like call:
+
+```python
+dyn.pl.topography(
+    adata,
+    basis="umap",
+    color=["ntr", "Cell_type"],
+    streamline_color="black",
+    show_legend="on data",
+    frontier=True,
+)
+```
+
+## Potential Trends
+
+After UMAP ddHodge potential is available:
+
+```python
+dyn.pl.umap(adata, color="umap_ddhodge_potential")
+```
+
+Use this only after verifying that `adata.obs["umap_ddhodge_potential"]` exists.
+
+## Stream Function Animation
+
+Primary entrypoints:
+
+- `dyn.mv.StreamFuncAnim(...)`
+- `dyn.mv.animate_fates(...)`
+
+Required prerequisite:
+
+- `dyn.pd.fate(...)` must already have populated `adata.uns["fate_<basis>"]`
+
+Notebook-like path:
+
+```python
+fig, ax = plt.subplots(figsize=(4, 4))
+ax = dyn.pl.topography(adata, color="Cell_type", ax=ax, save_show_or_return="return")
+
+instance = dyn.mv.StreamFuncAnim(
+    adata=adata,
+    color="Cell_type",
+    ax=ax,
+)
+```
+
+Or save directly:
+
+```python
+dyn.mv.animate_fates(
+    adata,
+    color="Cell_type",
+    basis="umap",
+    n_steps=100,
+    fig=fig,
+    ax=ax,
+    save_show_or_return="save",
+    logspace=True,
+    max_time=None,
+)
+```
+
+## Streamline GIF Path
+
+Notebook-specific optional path:
+
+1. `X_grid, V_grid = dyn.pl.compute_velocity_on_grid(...)`
+2. `dyn.pl.animate_streamplot(X_grid, V_grid, adata, ...)`
+
+This is presentation-heavy and not required for the analytical workflow.
+
+## Constraints
+
+- Do not let animation setup block the main analysis.
+- Keep `font_path='Arial'`, notebook magics, and background-color changes out of the default workflow unless the user explicitly wants presentation parity.
+- `animate_fates(..., save_show_or_return='save')` may require external animation tooling such as `imagemagick`.

--- a/skills/dynamo-differential-geometry-analysis/SKILL.md
+++ b/skills/dynamo-differential-geometry-analysis/SKILL.md
@@ -1,0 +1,230 @@
+---
+name: dynamo-differential-geometry-analysis
+description: Run downstream differential-geometry analysis on a `dynamo` vector-field `AnnData`, including velocity, acceleration, curvature, Jacobian, regulatory-network, ddhodge pseudotime, and state-graph branches. Use when adapting the `403_Differential_geometry.ipynb` tutorial, extending a conventional spliced/unspliced RNA velocity workflow into vector calculus, or choosing among `method`, `mode`, `sampling`, `formula`, `adjmethod`, or `gene_order_method` branches.
+---
+
+# Dynamo Differential Geometry Analysis
+
+## Goal
+
+Turn a conventional `dynamo` RNA-velocity dataset into reusable downstream differential-geometry outputs in PCA space, then optionally continue into Jacobian-based regulatory-network analysis, ddhodge pseudotime, kinetic heatmaps, and state graphs without treating the zebrafish notebook as the skill identity.
+
+## Quick Workflow
+
+1. Inspect whether the user already has a downstream-ready `AnnData` with `velocity_pca` and `VecFld_pca`, or whether raw conventional preprocessing and velocity fitting still need to happen.
+2. If starting from raw spliced / unspliced counts, preprocess with `recipe='monocle'`, fit dynamics, build the embedding, and compute both low-dimensional and PCA-space velocities.
+3. Fit `dyn.vf.VectorField(..., basis='pca')` before calling acceleration, curvature, Jacobian, or ddhodge on the PCA basis.
+4. Run the stage the user actually needs: scalar/vector geometry, Jacobian and ranking, regulatory-network extraction, or ddhodge pseudotime and state-graph analysis.
+5. Validate the concrete storage keys produced by each stage before interpreting plots or rankings.
+6. Export ranking tables or clean the object only after all downstream calculations that depend on `kinetics_heatmap`, fate, or vector-field internals are finished.
+
+## Interface Summary
+
+- `Preprocessor.preprocess_adata(adata, recipe='monocle', tkey=None, experiment_type=None)` is the conventional preprocessing wrapper.
+- `dyn.tl.reduceDimension(..., reduction_method='umap')` is the default embedding path; current source also exposes `trimap`, `diffusion_map`, `tsne`, `psl`, and `sude`.
+- `dyn.tl.cell_velocities(..., basis=None)` is the low-dimensional and PCA-space velocity entrypoint. In the current runtime, the `basis='pca'` branch may need an explicit `transition_genes` argument on smaller subsets.
+- `dyn.vf.VectorField(..., basis='pca', method='SparseVFC', pot_curl_div=False, **kwargs)` reconstructs the PCA-space vector field used by downstream differential geometry.
+- `dyn.vf.acceleration(..., basis='pca', method='analytical')` and `dyn.vf.curvature(..., basis='pca', formula=2, method='analytical')` generate per-cell and gene-space geometry outputs.
+- `dyn.vf.jacobian(..., sampling=None, sample_ncells=1000, basis='pca', method='analytical')` computes cell-wise Jacobians; `dyn.vf.rank_jacobian_genes(..., mode=...)` and `dyn.vf.build_network_per_cluster(...)` turn them into grouped rankings and edge lists.
+- `dyn.ext.ddhodge(..., basis='pca', adjmethod='graphize_vecfld', sampling_method='velocity')` creates vector-field pseudotime and potential, while `dyn.pl.kinetic_heatmap(..., mode='vector_field' | 'lap' | 'pseudotime')` and `dyn.pd.state_graph(..., method='vf' | 'markov' | 'naive')` consume those outputs.
+- `dyn.export_rank_xlsx(..., rank_prefix='rank')` exports ranking tables from `.uns`, and `dyn.cleanup(..., del_prediction=False, del_2nd_moments=False)` strips heavyweight internals before save.
+
+Read `references/source-grounding.md` before documenting narrower branch behavior than the current source supports.
+
+## Stage Selection
+
+- Use the bootstrap stage when the user starts from raw conventional spliced / unspliced data instead of an already fitted vector field.
+- Use the geometry-ranking stage when the user wants `velocity_S`, `acceleration`, or `curvature` rankings by cell group.
+- Use the Jacobian-network stage when the user wants regulator and effector ranking, interaction ranking, or a cluster-specific edge list.
+- Use the ddhodge-state stage when the user wants vector-field pseudotime, kinetic heatmaps, or cell-state transition graphs.
+- Keep `basis='pca'` for vector-field reconstruction, Jacobian, divergence-like ranking, ddhodge, and notebook-style state graphs. Use `basis='umap'` mainly for display or upstream velocity plots.
+- Keep `method='SparseVFC'`, `curvature(..., formula=2)`, `jacobian(..., method='analytical')`, `ddhodge(..., adjmethod='graphize_vecfld')`, and `state_graph(..., method='vf')` as the default reusable path unless the user explicitly asks for a different branch.
+
+Read `references/stage-selection.md` before choosing non-default `recipe`, `method`, `formula`, `sampling`, `mode`, `adjmethod`, or `gene_order_method` branches.
+
+## Input Contract
+
+- Expect an `AnnData` with conventional spliced / unspliced layers if the user wants the full bootstrap path.
+- Expect `adata.obsm['X_pca']`, `adata.var['use_for_pca']`, and `adata.layers['velocity_S']` before PCA-space vector-field analysis.
+- Expect `adata.obsm['velocity_pca']` and `adata.uns['VecFld_pca']` before calling acceleration, curvature, Jacobian, ddhodge, or `state_graph(..., method='vf', basis='pca')`.
+- Expect a meaningful grouping column such as `adata.obs['Cell_type']` before using ranking helpers or `build_network_per_cluster(...)`.
+- Expect `adata.uns['PCs']` or `adata.varm['PCs']` before `top_pca_genes(...)` or any PCA-basis inverse transform.
+- Treat notebook-specific zebrafish cell-type labels and genes such as `tfec` and `pnp4a` as worked-example defaults, not hard requirements.
+
+If the user only wants upstream preprocessing or only wants pseudotime-derived velocity without conventional kinetics, route to a more appropriate skill instead of forcing this downstream analysis path.
+
+## Minimal Execution Patterns
+
+For the default bootstrap from raw conventional zebrafish-style data:
+
+```python
+import dynamo as dyn
+
+adata = dyn.sample_data.zebrafish()
+adata.obs_names_make_unique()
+
+pre = dyn.pp.Preprocessor(cell_cycle_score_enable=True)
+pre.preprocess_adata(adata, recipe="monocle")
+
+dyn.tl.dynamics(adata, cores=1)
+dyn.tl.reduceDimension(adata)
+dyn.tl.cell_velocities(adata)
+dyn.tl.cell_velocities(
+    adata,
+    basis="pca",
+    transition_genes=adata.var.use_for_pca.values,
+)
+
+dyn.vf.VectorField(adata, basis="pca", M=50, cores=1)
+```
+
+For geometry and grouped ranking:
+
+```python
+dyn.vf.rank_velocity_genes(adata, groups="Cell_type", vkey="velocity_S")
+
+dyn.vf.acceleration(adata, basis="pca")
+dyn.vf.rank_acceleration_genes(adata, groups="Cell_type", akey="acceleration")
+
+dyn.vf.curvature(adata, basis="pca", formula=2)
+dyn.vf.rank_curvature_genes(adata, groups="Cell_type", ckey="curvature")
+```
+
+For Jacobian ranking and cluster-specific network extraction:
+
+```python
+dyn.pp.top_pca_genes(adata, n_top_genes=100)
+genes = adata.var_names[adata.var["top_pca_genes"]][:50].tolist()
+
+dyn.vf.jacobian(
+    adata,
+    regulators=genes,
+    effectors=genes,
+    sampling="trn",
+    sample_ncells=200,
+    basis="pca",
+)
+
+full_reg = dyn.vf.rank_jacobian_genes(
+    adata,
+    groups="Cell_type",
+    mode="full_reg",
+    abs=True,
+    return_df=True,
+)
+
+reg_rank = dyn.vf.rank_jacobian_genes(
+    adata,
+    groups="Cell_type",
+    mode="reg",
+    abs=True,
+    output_values=True,
+    return_df=True,
+)
+
+edges = dyn.vf.build_network_per_cluster(
+    adata,
+    cluster="Cell_type",
+    cluster_names=["Unknown"],
+    full_reg_rank=full_reg,
+    genes=genes[:20],
+    n_top_genes=10,
+    abs=True,
+)
+```
+
+For ddhodge pseudotime, kinetic heatmaps, and state graphs:
+
+```python
+dyn.ext.ddhodge(adata, basis="pca", sampling_method="velocity")
+
+transition_genes = adata.var_names[adata.var["top_pca_genes"]][:20].tolist()
+
+heat = dyn.pl.kinetic_heatmap(
+    adata,
+    genes=transition_genes,
+    basis="pca",
+    mode="pseudotime",
+    tkey="pca_ddhodge_potential",
+    gene_order_method="maximum",
+    save_show_or_return="return",
+)
+
+dyn.pd.state_graph(
+    adata,
+    group="Cell_type",
+    basis="pca",
+    method="vf",
+    sample_num=30,
+)
+```
+
+For export and cleanup after ranking:
+
+```python
+dyn.export_rank_xlsx(adata, path="result/rank_info.xlsx", rank_prefix="rank")
+dyn.cleanup(adata, del_prediction=False, del_2nd_moments=False)
+```
+
+## Validation
+
+After bootstrap preprocessing, check these items:
+
+- `adata.obsm["X_pca"]` exists
+- `adata.obsm["X_umap"]` exists if you ran the default embedding path
+- `adata.var["use_for_pca"]` and `adata.var["use_for_dynamics"]` exist
+- `adata.layers["velocity_S"]` exists after `cell_velocities(...)`
+
+After PCA velocity and vector-field fitting, check these items:
+
+- `adata.obsm["velocity_pca"]` exists
+- `adata.uns["VecFld_pca"]` exists
+- `adata.uns["VecFld_pca"]` includes `X`, `Y`, and vector-field parameters
+
+After geometry ranking, check these items:
+
+- `adata.layers["acceleration"]` exists
+- `adata.layers["curvature"]` exists
+- `adata.obs["acceleration_pca"]` and `adata.obs["curvature_pca"]` exist
+- ranking tables were written into `.uns` with `rank` or `rank_abs` prefixes
+
+After Jacobian and network analysis, check these items:
+
+- `adata.uns["jacobian_pca"]` exists
+- `adata.uns["jacobian_pca"]` includes `jacobian_gene`, `cell_idx`, `regulators`, and `effectors`
+- `full_reg` contains one table per requested group
+- `edges[group_name]` is a `DataFrame` with `regulator`, `target`, and `weight`
+
+After ddhodge, heatmap, and state graph, check these items:
+
+- `adata.obsp["pca_ddhodge"]` exists
+- `adata.obs["pca_ddhodge_potential"]` exists
+- `adata.uns["kinetics_heatmap"]` exists after `kinetic_heatmap(...)`
+- `adata.uns["Cell_type_graph"]` exists after `state_graph(...)`
+
+After cleanup and export, check these items:
+
+- the Excel file exists at the requested path
+- `cleanup(...)` removed `kinetics_heatmap` if it existed
+- `cleanup(...)` did not remove outputs you still need for downstream interpretation
+
+## Constraints
+
+- Do not assume `dyn.sample_data.zebrafish()` is already processed in the current runtime. Reviewer execution saw raw counts with `spliced` and `unspliced` layers but no downstream embedding or vector-field outputs.
+- Call `adata.obs_names_make_unique()` on the zebrafish worked example before concatenation or heavy preprocessing. Reviewer execution saw non-unique observation names.
+- Do not assume `dyn.tl.cell_velocities(adata, basis='pca')` is stable on small subsets without extra guidance. Reviewer execution needed `transition_genes=adata.var.use_for_pca.values` to avoid a PCA-projection failure.
+- Do not treat `jacobian(...)` as a whole-transcriptome default on large datasets. Narrow with `top_pca_genes(...)`, explicit regulators and effectors, or cell sampling first.
+- Do not imply that `rank_divergence_genes(...)` computes geometric divergence in the usual trace sense. Current source ranks diagonal Jacobian elements after `jacobian(...)`.
+- `ddhodge(..., adjmethod='naive')` depends on a preexisting transition matrix. Keep `adjmethod='graphize_vecfld'` unless the user explicitly wants the alternate branch and already has the needed adjacency.
+- `kinetic_heatmap(...)` stores results under `adata.uns["kinetics_heatmap"]`, and `cleanup(...)` removes that key.
+- `VectorField(..., method='dynode')` is a real branch but requires an additional backend. Do not recommend it by default.
+
+## Resource Map
+
+- Read `references/stage-selection.md` when choosing among bootstrap, geometry ranking, Jacobian/network, and ddhodge/state-graph stages.
+- Read `references/jacobian-and-network-analysis.md` when the user wants Jacobian ranking modes, divergence-like ranking, or cluster-specific regulatory edges.
+- Read `references/pseudotime-and-state-graph.md` when the user wants `ddhodge`, `kinetic_heatmap`, or `state_graph`.
+- Read `references/source-grounding.md` for inspected signatures, source-level branch evidence, and reviewer-run empirical execution notes.
+- Read `references/source-notebook-map.md` to trace `403_Differential_geometry.ipynb` into this reusable skill layout.
+- Read `references/compatibility.md` when notebook prose and current runtime behavior diverge.
+- Use `assets/acceptance.json` for the bounded smoke path used by local acceptance.

--- a/skills/dynamo-differential-geometry-analysis/assets/acceptance.json
+++ b/skills/dynamo-differential-geometry-analysis/assets/acceptance.json
@@ -1,0 +1,77 @@
+{
+  "version": 1,
+  "skill": "dynamo-differential-geometry-analysis",
+  "sample_requests": [
+    "Convert 403_Differential_geometry.ipynb into a reusable dynamo differential geometry workflow",
+    "Run dynamo vector-field differential geometry, Jacobian ranking, ddhodge pseudotime, and state graph analysis on an AnnData object"
+  ],
+  "required_description_terms": [
+    "dynamo",
+    "differential-geometry",
+    "jacobian",
+    "vector-field",
+    "anndata",
+    "tutorial"
+  ],
+  "required_sections": [
+    "## Goal",
+    "## Quick Workflow",
+    "## Interface Summary",
+    "## Stage Selection",
+    "## Minimal Execution Patterns",
+    "## Validation",
+    "## Resource Map"
+  ],
+  "required_body_terms": [
+    "cell_velocities",
+    "VectorField",
+    "acceleration",
+    "curvature",
+    "jacobian",
+    "rank_jacobian_genes",
+    "ddhodge",
+    "kinetic_heatmap",
+    "state_graph",
+    "kinetics_heatmap"
+  ],
+  "required_paths": [
+    "references/stage-selection.md",
+    "references/jacobian-and-network-analysis.md",
+    "references/pseudotime-and-state-graph.md",
+    "references/source-grounding.md",
+    "references/source-notebook-map.md",
+    "references/compatibility.md"
+  ],
+  "smoke_commands": [
+    {
+      "name": "geometry-jacobian-core",
+      "conda_env": "omictest",
+      "env": {
+        "MPLBACKEND": "Agg",
+        "MPLCONFIGDIR": "/tmp/mpl",
+        "NUMBA_CACHE_DIR": "/tmp/numba",
+        "PYTHONPATH": "/Users/fernandozeng/Desktop/analysis/dynamo-release"
+      },
+      "command": "${PYTHON} -c \"import anndata as ad, dynamo as dyn; adata=dyn.sample_data.zebrafish(); adata.obs_names_make_unique(); groups=['Proliferating Progenitor','Pigment Progenitor','Melanophore','Unknown']; parts=[adata[adata.obs['Cell_type']==g][:30].copy() for g in groups]; adata=ad.concat(parts, merge='same', label='subset_batch', keys=groups, index_unique='-'); adata.obs_names_make_unique(); pre=dyn.pp.Preprocessor(cell_cycle_score_enable=True); pre.preprocess_adata(adata, recipe='monocle'); dyn.tl.dynamics(adata, cores=1); dyn.tl.reduceDimension(adata); dyn.tl.cell_velocities(adata); dyn.tl.cell_velocities(adata, basis='pca', transition_genes=adata.var.use_for_pca.values); dyn.vf.VectorField(adata, basis='pca', M=50, cores=1); dyn.vf.rank_velocity_genes(adata, groups='Cell_type', vkey='velocity_S'); dyn.vf.acceleration(adata, basis='pca'); dyn.vf.rank_acceleration_genes(adata, groups='Cell_type', akey='acceleration'); dyn.vf.curvature(adata, basis='pca'); dyn.vf.rank_curvature_genes(adata, groups='Cell_type', ckey='curvature'); dyn.pp.top_pca_genes(adata, n_top_genes=20); genes=adata.var_names[adata.var['top_pca_genes']][:10].tolist(); dyn.vf.jacobian(adata, regulators=genes, effectors=genes, sampling='trn', sample_ncells=60, basis='pca'); full_reg=dyn.vf.rank_jacobian_genes(adata, groups='Cell_type', mode='full_reg', abs=True, return_df=True); edges=dyn.vf.build_network_per_cluster(adata, cluster='Cell_type', cluster_names=['Unknown'], full_reg_rank=full_reg, genes=genes, n_top_genes=10, abs=True); print('velocity_pca' in adata.obsm, 'VecFld_pca' in adata.uns, 'acceleration' in adata.layers, 'curvature' in adata.layers, 'jacobian_pca' in adata.uns, edges['Unknown'].shape[0] > 0)\"",
+      "timeout_seconds": 420,
+      "expect_stdout_contains": [
+        "True True True True True True"
+      ]
+    },
+    {
+      "name": "ddhodge-state-graph-heatmap",
+      "conda_env": "omictest",
+      "env": {
+        "MPLBACKEND": "Agg",
+        "MPLCONFIGDIR": "/tmp/mpl",
+        "NUMBA_CACHE_DIR": "/tmp/numba",
+        "PYTHONPATH": "/Users/fernandozeng/Desktop/analysis/dynamo-release"
+      },
+      "command": "${PYTHON} -c \"import anndata as ad, dynamo as dyn; adata=dyn.sample_data.zebrafish(); adata.obs_names_make_unique(); groups=['Proliferating Progenitor','Pigment Progenitor','Melanophore','Unknown']; parts=[adata[adata.obs['Cell_type']==g][:30].copy() for g in groups]; adata=ad.concat(parts, merge='same', label='subset_batch', keys=groups, index_unique='-'); adata.obs_names_make_unique(); pre=dyn.pp.Preprocessor(cell_cycle_score_enable=True); pre.preprocess_adata(adata, recipe='monocle'); dyn.tl.dynamics(adata, cores=1); dyn.tl.reduceDimension(adata); dyn.tl.cell_velocities(adata); dyn.tl.cell_velocities(adata, basis='pca', transition_genes=adata.var.use_for_pca.values); dyn.vf.VectorField(adata, basis='pca', M=50, cores=1); dyn.pp.top_pca_genes(adata, n_top_genes=20); transition_genes=adata.var_names[adata.var['top_pca_genes']][:10].tolist(); dyn.ext.ddhodge(adata, basis='pca', n_downsamples=5000); heat=dyn.pl.kinetic_heatmap(adata, genes=transition_genes, basis='pca', mode='pseudotime', tkey='pca_ddhodge_potential', gene_order_method='maximum', save_show_or_return='return'); dyn.pd.state_graph(adata, group='Cell_type', basis='pca', method='vf', sample_num=15); print('pca_ddhodge' in adata.obsp, 'pca_ddhodge_potential' in adata.obs, 'kinetics_heatmap' in adata.uns, 'Cell_type_graph' in adata.uns, type(heat).__name__)\"",
+      "timeout_seconds": 420,
+      "expect_stdout_contains": [
+        "True True True True ClusterGrid"
+      ]
+    }
+  ]
+}

--- a/skills/dynamo-differential-geometry-analysis/references/compatibility.md
+++ b/skills/dynamo-differential-geometry-analysis/references/compatibility.md
@@ -1,0 +1,42 @@
+# Compatibility
+
+Use this reference when notebook wording and current runtime behavior are not identical.
+
+## Current API Preference
+
+Prefer the current callable paths:
+
+- `dyn.pp.Preprocessor`
+- `dyn.tl.dynamics`
+- `dyn.tl.cell_velocities`
+- `dyn.vf.VectorField`
+- `dyn.vf.acceleration`
+- `dyn.vf.curvature`
+- `dyn.vf.jacobian`
+- `dyn.ext.ddhodge`
+- `dyn.pd.state_graph`
+
+Do not present the notebook as if it were the API contract.
+
+## Source Vs Notebook
+
+- The notebook presentation reads like the zebrafish example is already downstream-ready. Reviewer execution showed `dyn.sample_data.zebrafish()` is raw in the current runtime and needs preprocessing, dynamics, embedding, and velocity fitting.
+- Reviewer execution found non-unique observation names on the zebrafish worked example, so `obs_names_make_unique()` is part of the practical bootstrap path.
+- The notebook shows the simple `cell_velocities(..., basis='pca')` call. Reviewer execution on smaller subsets needed `transition_genes=adata.var.use_for_pca.values` for that branch to succeed reliably.
+- `kinetic_heatmap(...)` stores under `adata.uns['kinetics_heatmap']`, and `cleanup(...)` removes that key. The notebook does not call out that interaction.
+- `rank_divergence_genes(...)` ranks diagonal Jacobian elements, not the usual geometric divergence trace.
+- `state_graph(..., method='vf')` can emit warnings on sparse or lightly sampled group transitions while still producing a usable `'<group>_graph'` payload.
+
+## Runtime Constraints
+
+- Importing `dynamo` for reviewer execution was done in a repository-compatible Python environment with the repository root on `PYTHONPATH`.
+- `VectorField(..., method='dynode')` is a real branch but depends on an additional backend that was not required for the default path.
+- `kinetic_heatmap(..., save_show_or_return='show')` is not ideal for headless validation. Use `'return'` in smoke tests and automated review.
+
+## Conservative Rule
+
+If notebook text and live source disagree:
+
+1. trust the current source for executable behavior
+2. mention the divergence explicitly
+3. keep the notebook only as a worked example or parity reference

--- a/skills/dynamo-differential-geometry-analysis/references/jacobian-and-network-analysis.md
+++ b/skills/dynamo-differential-geometry-analysis/references/jacobian-and-network-analysis.md
@@ -1,0 +1,173 @@
+# Jacobian And Network Analysis
+
+Use this reference when the user wants regulatory interpretation instead of only scalar geometry.
+
+## Preconditions
+
+Before running any Jacobian-derived analysis, confirm:
+
+- `adata.uns['VecFld_pca']` exists
+- `adata.uns['PCs']` or `adata.varm['PCs']` exists
+- the gene set is narrowed to something tractable
+
+The notebook does not make the scaling problem explicit enough. Whole-transcriptome Jacobians are expensive in both memory and interpretation.
+
+## Shrink The Gene Universe First
+
+Current helper:
+
+```python
+dyn.pp.top_pca_genes(
+    adata,
+    pc_key="PCs",
+    n_top_genes=100,
+    pc_components=None,
+    adata_store_key="top_pca_genes",
+)
+```
+
+Storage rule:
+
+- `top_pca_genes(...)` writes a boolean mask to `adata.var['top_pca_genes']`
+
+Recommended pattern:
+
+```python
+dyn.pp.top_pca_genes(adata, n_top_genes=100)
+genes = adata.var_names[adata.var["top_pca_genes"]][:50].tolist()
+```
+
+## Jacobian Core
+
+Current callable:
+
+```python
+dyn.vf.jacobian(
+    adata,
+    regulators=None,
+    effectors=None,
+    cell_idx=None,
+    sampling=None,
+    sample_ncells=1000,
+    basis="pca",
+    Qkey="PCs",
+    vector_field_class=None,
+    method="analytical",
+    store_in_adata=True,
+)
+```
+
+Branch notes:
+
+- `sampling=None` uses all available cells
+- `sampling='random'` samples uniformly
+- `sampling='velocity'` samples by velocity magnitude
+- `sampling='trn'` uses the transition-gene based branch
+- `method='analytical'` is the default reusable path
+- `method='numerical'` exists for branch comparison or debugging
+
+Storage rule:
+
+- `jacobian(..., basis='pca')` writes `adata.uns['jacobian_pca']`
+- determinant summaries are written to `adata.obs['jacobian_det_pca']`
+
+## Ranking Modes
+
+Current `rank_jacobian_genes(...)` modes:
+
+- `full reg` or `full_reg`
+- `full eff` or `full_eff`
+- `reg`
+- `eff`
+- `int`
+- `switch`
+
+Interpretation:
+
+- `full_reg`: ranked regulators for every effector in each group
+- `full_eff`: ranked effectors for every regulator in each group
+- `reg`: grouped summary focused on regulators
+- `eff`: grouped summary focused on effectors
+- `int`: pairwise interaction ranking
+- `switch`: mutual inhibition candidates
+
+Recommended usage:
+
+```python
+full_reg = dyn.vf.rank_jacobian_genes(
+    adata,
+    groups="Cell_type",
+    mode="full_reg",
+    abs=True,
+    return_df=True,
+)
+
+reg_rank = dyn.vf.rank_jacobian_genes(
+    adata,
+    groups="Cell_type",
+    mode="reg",
+    abs=True,
+    output_values=True,
+    return_df=True,
+)
+```
+
+## Divergence-Like Ranking
+
+Current helper:
+
+```python
+dyn.vf.rank_divergence_genes(
+    adata,
+    jkey="jacobian_pca",
+    genes=None,
+    prefix_store="rank_div_gene",
+)
+```
+
+Important source detail:
+
+- this helper ranks diagonal Jacobian elements
+- it does not compute geometric divergence as the full Jacobian trace in the usual vector-calculus sense
+- it requires `regulators == effectors` in the stored Jacobian
+
+## Build Cluster-Specific Networks
+
+Current helper:
+
+```python
+dyn.vf.build_network_per_cluster(
+    adata,
+    cluster,
+    cluster_names=None,
+    full_reg_rank=None,
+    full_eff_rank=None,
+    genes=None,
+    n_top_genes=100,
+    abs=False,
+)
+```
+
+Observed behavior:
+
+- if `full_reg_rank` or `full_eff_rank` is missing, the helper recomputes grouped ranking internally
+- it returns a dict keyed by cluster name
+- each value is a `DataFrame` with `regulator`, `target`, and `weight`
+
+Recommended pattern:
+
+```python
+edges = dyn.vf.build_network_per_cluster(
+    adata,
+    cluster="Cell_type",
+    cluster_names=["Unknown"],
+    full_reg_rank=full_reg,
+    genes=genes[:20],
+    n_top_genes=10,
+    abs=True,
+)
+```
+
+## Plotting Handoff
+
+Only move into `dyn.pl.jacobian(...)`, `dyn.pl.arcPlot(...)`, or `dyn.pl.circosPlot(...)` after the underlying Jacobian or edge list has been validated. The notebook interleaves plotting with interpretation, but the reusable skill should treat those as downstream consumers.

--- a/skills/dynamo-differential-geometry-analysis/references/pseudotime-and-state-graph.md
+++ b/skills/dynamo-differential-geometry-analysis/references/pseudotime-and-state-graph.md
@@ -1,0 +1,138 @@
+# Pseudotime And State Graph
+
+Use this reference when the user wants vector-field pseudotime, heatmaps, or group-level transition graphs after geometry and Jacobian work.
+
+## ddhodge Core
+
+Current callable:
+
+```python
+dyn.ext.ddhodge(
+    adata,
+    X_data=None,
+    layer=None,
+    basis="pca",
+    n=30,
+    VecFld=None,
+    adjmethod="graphize_vecfld",
+    distance_free=False,
+    n_downsamples=5000,
+    up_sampling=True,
+    sampling_method="velocity",
+    seed=19491001,
+    enforce=False,
+    cores=1,
+)
+```
+
+Observed branch-heavy parameters:
+
+- `adjmethod`: `graphize_vecfld`, `naive`
+- `sampling_method`: `random`, `velocity`, `trn`
+
+Storage rules:
+
+- `adata.obsp['pca_ddhodge']`
+- `adata.obs['pca_ddhodge_div']`
+- `adata.obs['pca_ddhodge_potential']`
+
+Recommendation:
+
+- use `basis='pca'`
+- keep `adjmethod='graphize_vecfld'`
+- keep `sampling_method='velocity'`
+
+When to switch:
+
+- use `adjmethod='naive'` only when a suitable adjacency or transition matrix already exists and the user explicitly wants that branch
+- use `sampling_method='trn'` only when the user wants the transition-gene-driven cell subsampling branch
+
+## kinetic_heatmap
+
+Current callable shape:
+
+```python
+dyn.pl.kinetic_heatmap(
+    adata,
+    genes,
+    mode="vector_field",
+    basis=None,
+    layer="X",
+    project_back_to_high_dim=True,
+    tkey="potential",
+    gene_order_method="maximum",
+    save_show_or_return="show",
+)
+```
+
+Observed branch-heavy parameters:
+
+- `mode`: `vector_field`, `lap`, `pseudotime`
+- `gene_order_method`: `maximum`, `half_max_ordering`, `raw`
+
+Important source details:
+
+- current source stores results under `adata.uns['kinetics_heatmap']`
+- when `mode='pseudotime'` and the requested `tkey` is missing, current source can auto-run `ddhodge(adata)` on defaults
+
+Recommendation:
+
+- use `mode='pseudotime'`
+- use `basis='pca'`
+- use `tkey='pca_ddhodge_potential'`
+- use `gene_order_method='maximum'`
+- use `save_show_or_return='return'` in validation or headless environments
+
+## state_graph
+
+Current callable:
+
+```python
+dyn.pd.state_graph(
+    adata,
+    group,
+    method="vf",
+    transition_mat_key="pearson_transition_matrix",
+    approx=False,
+    eignum=5,
+    basis="umap",
+    layer=None,
+    arc_sample=False,
+    sample_num=100,
+    prune_graph=False,
+)
+```
+
+Observed branch-heavy parameters:
+
+- `method`: `vf`, `markov`, `naive`
+
+Storage rule:
+
+- `state_graph(..., group='Cell_type')` writes `adata.uns['Cell_type_graph']`
+- that payload includes `group_graph`, `group_avg_time`, and `group_names`
+
+Recommendation:
+
+- use `group='<group>'`
+- use `basis='pca'` when the vector field was fit in PCA space
+- use `method='vf'`
+- keep `sample_num` moderate on subsets
+
+When to switch:
+
+- use `method='markov'` or `method='naive'` only when the user explicitly wants a transition-matrix interpretation instead of vector-field integration
+- use `prune_graph=True` only when the user wants a pruned state graph and accepts the extra similarity-graph dependency
+
+## Practical Sequence
+
+Recommended order:
+
+1. `ddhodge(...)`
+2. `kinetic_heatmap(...)`
+3. `state_graph(...)`
+
+Reason:
+
+- `kinetic_heatmap(..., mode='pseudotime')` and notebook interpretation both depend on vector-field pseudotime
+- `state_graph(..., method='vf')` works best after the PCA vector field is already validated

--- a/skills/dynamo-differential-geometry-analysis/references/source-grounding.md
+++ b/skills/dynamo-differential-geometry-analysis/references/source-grounding.md
@@ -1,0 +1,295 @@
+# Source Grounding
+
+This skill was generated from live code inspection and reviewer-run execution in the current repository, not from notebook narration alone.
+
+## Primary Source Files
+
+Notebook inspected:
+
+- `docs/tutorials/notebooks/403_Differential_geometry.ipynb`
+
+Code inspected:
+
+- `dynamo/preprocessing/Preprocessor.py`
+- `dynamo/preprocessing/pca.py`
+- `dynamo/vectorfield/VectorField.py`
+- `dynamo/vectorfield/vector_calculus.py`
+- `dynamo/vectorfield/rank_vf.py`
+- `dynamo/vectorfield/networks.py`
+- `dynamo/external/hodge.py`
+- `dynamo/plot/time_series.py`
+- `dynamo/prediction/state_graph.py`
+- `dynamo/data_io.py`
+
+## Inspected Interfaces
+
+### `Preprocessor.preprocess_adata`
+
+Observed signature:
+
+```python
+(self, adata, recipe='monocle', tkey=None, experiment_type=None) -> None
+```
+
+Observed `recipe` branches:
+
+- `monocle`
+- `seurat`
+- `sctransform`
+- `pearson_residuals`
+- `monocle_pearson_residuals`
+
+### `dyn.vf.VectorField`
+
+Observed signature:
+
+```python
+(adata, basis=None, layer=None, dims=None, genes=None, normalize=False, grid_velocity=False, grid_num=50, velocity_key='velocity_S', method='SparseVFC', min_vel_corr=0.6, restart_num=5, restart_seed=[0, 100, 200, 300, 400], model_buffer_path=None, return_vf_object=False, map_topography=False, pot_curl_div=False, cores=1, result_key=None, copy=False, n=25, **kwargs)
+```
+
+Observed `method` branches:
+
+- `SparseVFC`
+- `dynode`
+
+Important source detail:
+
+- notebook argument `M=50` or `M=1000` is forwarded through `**kwargs`, not exposed in the public signature
+
+### `dyn.vf.acceleration`
+
+Observed signature:
+
+```python
+(adata, basis='umap', vector_field_class=None, Qkey='PCs', method='analytical', **kwargs)
+```
+
+Observed `method` branches:
+
+- `analytical`
+- `numerical`
+
+Observed PCA-basis storage:
+
+- `adata.obs['acceleration_pca']`
+- `adata.obsm['acceleration_pca']`
+- `adata.layers['acceleration']`
+
+### `dyn.vf.curvature`
+
+Observed signature:
+
+```python
+(adata, basis='pca', vector_field_class=None, formula=2, Qkey='PCs', method='analytical', **kwargs)
+```
+
+Observed branch-heavy parameters:
+
+- `formula`: `1`, `2`
+- `method`: `analytical`, `numerical`
+
+Observed PCA-basis storage:
+
+- `adata.obs['curvature_pca']`
+- `adata.obsm['curvature_pca']`
+- `adata.layers['curvature']`
+
+### `dyn.vf.jacobian`
+
+Observed signature:
+
+```python
+(adata, regulators=None, effectors=None, cell_idx=None, sampling=None, sample_ncells=1000, basis='pca', Qkey='PCs', vector_field_class=None, method='analytical', store_in_adata=True, **kwargs)
+```
+
+Observed `sampling` branches:
+
+- `None`
+- `random`
+- `velocity`
+- `trn`
+
+Observed `method` branches:
+
+- `analytical`
+- `numerical`
+
+Observed storage:
+
+- `adata.uns['jacobian_pca']`
+- `adata.obs['jacobian_det_pca']`
+
+### `dyn.vf.rank_jacobian_genes`
+
+Observed signature:
+
+```python
+(adata, groups=None, jkey='jacobian_pca', abs=False, mode='full reg', exclude_diagonal=False, normalize=False, return_df=False, **kwargs)
+```
+
+Observed `mode` branches:
+
+- `full reg` or `full_reg`
+- `full eff` or `full_eff`
+- `reg`
+- `eff`
+- `int`
+- `switch`
+
+### `dyn.vf.rank_divergence_genes`
+
+Observed signature:
+
+```python
+(adata, jkey='jacobian_pca', genes=None, prefix_store='rank_div_gene', **kwargs)
+```
+
+Important source detail:
+
+- this helper ranks diagonal Jacobian elements after `jacobian(...)`
+- it requires matching regulators and effectors in the stored Jacobian
+
+### `dyn.pp.top_pca_genes`
+
+Observed signature:
+
+```python
+(adata, pc_key='PCs', n_top_genes=100, pc_components=None, adata_store_key='top_pca_genes')
+```
+
+Observed storage:
+
+- writes a boolean mask into `adata.var['top_pca_genes']`
+
+### `dyn.ext.ddhodge`
+
+Observed signature:
+
+```python
+(adata, X_data=None, layer=None, basis='pca', n=30, VecFld=None, adjmethod='graphize_vecfld', distance_free=False, n_downsamples=5000, up_sampling=True, sampling_method='velocity', seed=19491001, enforce=False, cores=1, **kwargs)
+```
+
+Observed branch-heavy parameters:
+
+- `adjmethod`: `graphize_vecfld`, `naive`
+- `sampling_method`: `random`, `velocity`, `trn`
+
+Observed storage:
+
+- `adata.obsp['pca_ddhodge']`
+- `adata.obs['pca_ddhodge_div']`
+- `adata.obs['pca_ddhodge_potential']`
+
+### `dyn.pl.kinetic_heatmap`
+
+Observed signature includes:
+
+```python
+(adata, genes, mode='vector_field', basis=None, layer='X', project_back_to_high_dim=True, tkey='potential', dist_threshold=1e-10, color_map='BrBG', gene_order_method='maximum', ..., save_show_or_return='show', ...)
+```
+
+Observed branch-heavy parameters:
+
+- `mode`: `vector_field`, `lap`, `pseudotime`
+- `gene_order_method`: `maximum`, `half_max_ordering`, `raw`
+
+Important source detail:
+
+- current source writes to `adata.uns['kinetics_heatmap']`
+
+### `dyn.pd.state_graph`
+
+Observed signature:
+
+```python
+(adata, group, method='vf', transition_mat_key='pearson_transition_matrix', approx=False, eignum=5, basis='umap', layer=None, arc_sample=False, sample_num=100, prune_graph=False, **kwargs)
+```
+
+Observed `method` branches:
+
+- `vf`
+- `markov`
+- `naive`
+
+Observed storage:
+
+- `adata.uns['<group>_graph']`
+
+### Export Helpers
+
+Observed signatures:
+
+```python
+export_rank_xlsx(adata, path='rank_info.xlsx', ext='excel', rank_prefix='rank') -> None
+cleanup(adata, del_prediction=False, del_2nd_moments=False) -> AnnData
+```
+
+Important source detail:
+
+- `cleanup(...)` removes `adata.uns['kinetics_heatmap']` if present
+
+## Reviewer-Run Empirical Checks
+
+### Worked Example Data State
+
+Observed on `dyn.sample_data.zebrafish()` in the current runtime:
+
+- shape `4181 x 16940`
+- `.layers` includes `spliced`, `unspliced`
+- `.obsm` is empty before preprocessing
+- `.obsp` is empty before preprocessing
+- `.uns` is empty before preprocessing
+- observation names are not unique
+
+This matters because the notebook wording reads like a processed example, but the current runtime provides raw conventional data.
+
+### Stable Bootstrap And Geometry Path
+
+Reviewer execution succeeded on a `118`-cell subset spanning:
+
+- `Proliferating Progenitor`
+- `Pigment Progenitor`
+- `Melanophore`
+- `Unknown`
+
+Executed sequence:
+
+1. `obs_names_make_unique()`
+2. `Preprocessor(...).preprocess_adata(..., recipe='monocle')`
+3. `dynamics(..., cores=1)`
+4. `reduceDimension(...)`
+5. `cell_velocities(adata)` for the embedding
+6. `cell_velocities(adata, basis='pca', transition_genes=adata.var.use_for_pca.values)`
+7. `VectorField(adata, basis='pca', M=50)`
+8. `acceleration(adata, basis='pca')`
+9. `curvature(adata, basis='pca')`
+10. `top_pca_genes(adata, n_top_genes=20)`
+11. `jacobian(..., sampling='trn', sample_ncells=60, basis='pca')`
+12. `rank_jacobian_genes(..., mode='full_reg')`
+13. `build_network_per_cluster(...)`
+14. `ddhodge(adata, basis='pca')`
+15. `state_graph(adata, group='Cell_type', basis='pca', method='vf', sample_num=15)`
+16. `kinetic_heatmap(..., mode='pseudotime', tkey='pca_ddhodge_potential', save_show_or_return='return')`
+
+Observed outputs:
+
+- `velocity_umap`
+- `velocity_pca`
+- `pearson_transition_matrix`
+- `VecFld_pca`
+- `acceleration`
+- `curvature`
+- `jacobian_pca`
+- `pca_ddhodge`
+- `pca_ddhodge_potential`
+- `Cell_type_graph`
+- `kinetics_heatmap`
+
+### Important Runtime Trap
+
+Reviewer execution found a stable PCA projection fix:
+
+- `cell_velocities(adata, basis='pca')` can fail on smaller subsets
+- `cell_velocities(adata, basis='pca', transition_genes=adata.var.use_for_pca.values)` succeeded reliably on the checked subset
+
+That fix is encoded in the skill because it came from live execution, not notebook prose.

--- a/skills/dynamo-differential-geometry-analysis/references/source-notebook-map.md
+++ b/skills/dynamo-differential-geometry-analysis/references/source-notebook-map.md
@@ -1,0 +1,162 @@
+# Source Notebook Map
+
+Source notebook:
+`docs/tutorials/notebooks/403_Differential_geometry.ipynb`
+
+Use this file to see how the notebook was converted into a reusable downstream differential-geometry skill.
+
+Conversion rule used here:
+
+- the stable skill identity is downstream `dynamo` differential-geometry analysis on a conventional RNA-velocity vector field
+- zebrafish pigmentation is the worked example, not the trigger surface
+
+## Notebook Sections To Skill Responsibilities
+
+### 1. Load Or Preprocess Data
+
+Notebook role:
+
+- load `dyn.sample_data.zebrafish()`
+- preprocess and fit dynamics
+
+Preserved in the skill:
+
+- `SKILL.md` Quick Workflow
+- `SKILL.md` Input Contract
+- `references/stage-selection.md`
+- `references/source-grounding.md`
+
+Source-grounded addition:
+
+- the current runtime provides raw zebrafish counts, so the reusable skill treats preprocessing as a real bootstrap stage instead of assuming a processed object
+
+### 2. Learn The PCA-Space Vector Field
+
+Notebook role:
+
+- compute PCA-space velocity
+- fit `VectorField(..., basis='pca')`
+
+Preserved in the skill:
+
+- `SKILL.md` Interface Summary
+- `SKILL.md` Minimal Execution Patterns
+- `references/stage-selection.md`
+
+Source-grounded addition:
+
+- reviewer execution found that smaller subsets may need `transition_genes=adata.var.use_for_pca.values` for the `basis='pca'` velocity branch
+
+### 3. Velocity, Acceleration, And Curvature Ranking
+
+Notebook role:
+
+- rank velocity genes
+- compute acceleration and curvature
+- rank acceleration and curvature genes
+
+Preserved in the skill:
+
+- `SKILL.md` Stage Selection
+- `SKILL.md` Minimal Execution Patterns
+- `SKILL.md` Validation
+
+Source-grounded addition:
+
+- the skill records the real `method` and `formula` branches, not only the notebook's default path
+
+### 4. Gene Set Enrichment
+
+Notebook role:
+
+- run `dyn.ext.enrichr(...)` on selected ranked genes
+
+Conversion choice:
+
+- not part of the core skill identity
+- intentionally left out of the main workflow because it is a downstream interpretation consumer of ranking outputs, not a defining step of differential-geometry analysis
+
+### 5. Jacobian Calculation, Ranking, And Network Construction
+
+Notebook role:
+
+- mark top PCA genes
+- compute Jacobian
+- rank Jacobian-derived quantities
+- build and plot cluster-specific networks
+
+Preserved in the skill:
+
+- `SKILL.md` Minimal Execution Patterns
+- `references/jacobian-and-network-analysis.md`
+
+Source-grounded additions:
+
+- explicit `sampling` branches on `jacobian(...)`
+- explicit `mode` branches on `rank_jacobian_genes(...)`
+- explicit returned edge-list shape from `build_network_per_cluster(...)`
+
+### 6. ddhodge Pseudotime And Heatmaps
+
+Notebook role:
+
+- run `ddhodge(...)`
+- plot kinetic heatmaps for expression, velocity, acceleration, and curvature
+
+Preserved in the skill:
+
+- `SKILL.md` Stage Selection
+- `references/pseudotime-and-state-graph.md`
+
+Source-grounded additions:
+
+- explicit `adjmethod`, `sampling_method`, `mode`, and `gene_order_method` branches
+- explicit storage key `adata.uns['kinetics_heatmap']`
+
+### 7. State Graph
+
+Notebook role:
+
+- run `state_graph(..., method='vf')`
+- plot the resulting state graph
+
+Preserved in the skill:
+
+- `SKILL.md` Minimal Execution Patterns
+- `references/pseudotime-and-state-graph.md`
+
+Source-grounded addition:
+
+- the skill treats `method='markov'` and `method='naive'` as real alternate branches even though the notebook demonstrates only `vf`
+
+### 8. Export And Cleanup
+
+Notebook role:
+
+- export rank tables to Excel
+- call `cleanup(...)`
+
+Preserved in the skill:
+
+- `SKILL.md` Minimal Execution Patterns
+- `SKILL.md` Constraints
+- `references/source-grounding.md`
+
+Source-grounded addition:
+
+- `cleanup(...)` removes `kinetics_heatmap`, so the skill keeps export and cleanup at the very end
+
+## What Was Intentionally Not Carried Over
+
+- zebrafish-specific biological interpretation prose
+- figure-by-figure plot commentary
+- direct presentation choices such as plotting style or notebook display layout
+- enrichment analysis as a default branch
+
+## When To Reopen The Notebook
+
+Reopen the notebook only when:
+
+- the user wants zebrafish-specific figure parity
+- the user wants the same exact genes or cell types used in the teaching narrative
+- a future notebook revision changes the demonstrated order of vector-field, Jacobian, or ddhodge stages

--- a/skills/dynamo-differential-geometry-analysis/references/stage-selection.md
+++ b/skills/dynamo-differential-geometry-analysis/references/stage-selection.md
@@ -1,0 +1,144 @@
+# Stage Selection
+
+This notebook mixes upstream velocity fitting, downstream differential geometry, ranking, network extraction, pseudotime, and reporting. Keep those jobs separate instead of replaying the notebook line by line.
+
+## Capability Partition
+
+- Core executable job:
+  bootstrap a conventional spliced / unspliced `AnnData` into a PCA-space vector field, then compute differential-geometry quantities from that field
+- Optional downstream analysis jobs:
+  grouped ranking, Jacobian ranking, regulatory-network extraction, ddhodge pseudotime, kinetic heatmaps, and state graphs
+- Optional visualization and reporting jobs:
+  UMAP overlays, Jacobian plots, arc plots, circos plots, streamline plots, and Excel export
+- Notebook-only pedagogy:
+  zebrafish biology explanation, figure narration, and cell-by-cell interpretation prose
+
+## Default Job
+
+If the user asks for the reusable equivalent of `403_Differential_geometry.ipynb`:
+
+1. preprocess with `recipe='monocle'`
+2. run `dynamics(...)`
+3. run `reduceDimension(...)`
+4. compute velocity in the embedding and in PCA space
+5. fit `VectorField(..., basis='pca', method='SparseVFC')`
+6. branch into geometry ranking, Jacobian analysis, or ddhodge/state-graph analysis as needed
+
+## Stage 1: Bootstrap From Raw Conventional Data
+
+Relevant branch-heavy parameters:
+
+- `Preprocessor.preprocess_adata(..., recipe=...)`
+- `dyn.tl.reduceDimension(..., reduction_method=...)`
+- `dyn.tl.cell_velocities(..., basis=None | 'pca')`
+
+Observed `recipe` branches:
+
+- `monocle`
+- `seurat`
+- `sctransform`
+- `pearson_residuals`
+- `monocle_pearson_residuals`
+
+Observed `reduction_method` branches:
+
+- `trimap`
+- `diffusion_map`
+- `tsne`
+- `umap`
+- `psl`
+- `sude`
+
+Recommendation:
+
+- use `recipe='monocle'`
+- use `reduction_method='umap'`
+- compute both the default embedding velocity and `basis='pca'` velocity
+
+Important runtime rule:
+
+- on smaller subsets, prefer `dyn.tl.cell_velocities(..., basis='pca', transition_genes=adata.var.use_for_pca.values)` instead of relying on the narrower default call
+
+## Stage 2: Vector Field And Scalar / Vector Geometry
+
+Relevant branch-heavy parameters:
+
+- `VectorField(..., method='SparseVFC' | 'dynode', pot_curl_div=False | True)`
+- `acceleration(..., method='analytical' | 'numerical')`
+- `curvature(..., formula=1 | 2, method='analytical' | 'numerical')`
+
+Recommendation:
+
+- use `basis='pca'`
+- use `method='SparseVFC'`
+- keep `pot_curl_div=False` unless the user explicitly wants curl or divergence on a 2D basis
+- use `acceleration(..., method='analytical')`
+- use `curvature(..., formula=2, method='analytical')`
+
+When to switch:
+
+- use `method='dynode'` only when that backend is installed and explicitly requested
+- use `formula=1` only when the user explicitly wants the alternate curvature definition
+- use `method='numerical'` only for comparison, debugging, or branch audits
+
+## Stage 3: Jacobian And Ranking
+
+Relevant branch-heavy parameters:
+
+- `jacobian(..., sampling=None | 'random' | 'velocity' | 'trn', method='analytical' | 'numerical')`
+- `rank_jacobian_genes(..., mode='full reg' | 'full eff' | 'reg' | 'eff' | 'int' | 'switch')`
+
+Recommendation:
+
+- shrink the gene universe first with `top_pca_genes(...)`
+- use `jacobian(..., basis='pca', sampling='trn', method='analytical')`
+- use `mode='full_reg'` or `mode='full_eff'` when you need whole-group ranking tables
+- use `mode='reg'` or `mode='eff'` when you need target-specific summaries
+
+When to switch:
+
+- use `sampling='random'` or `sampling='velocity'` only when you explicitly want a different cell subset policy
+- use `mode='int'` when you want pairwise interaction ranking
+- use `mode='switch'` only when the task is to identify mutual inhibition candidates
+
+## Stage 4: ddhodge Pseudotime, Heatmaps, And State Graphs
+
+Relevant branch-heavy parameters:
+
+- `ddhodge(..., adjmethod='graphize_vecfld' | 'naive', sampling_method='random' | 'velocity' | 'trn')`
+- `kinetic_heatmap(..., mode='vector_field' | 'lap' | 'pseudotime', gene_order_method='maximum' | 'half_max_ordering' | 'raw')`
+- `state_graph(..., method='vf' | 'markov' | 'naive')`
+
+Recommendation:
+
+- use `ddhodge(..., basis='pca', adjmethod='graphize_vecfld', sampling_method='velocity')`
+- use `kinetic_heatmap(..., mode='pseudotime', tkey='pca_ddhodge_potential', gene_order_method='maximum')`
+- use `state_graph(..., group='<group>', basis='pca', method='vf')`
+
+When to switch:
+
+- use `adjmethod='naive'` only if a relevant adjacency or transition matrix already exists and you explicitly want that branch
+- use `mode='vector_field'` when the user wants ordering along the vector field without ddhodge pseudotime
+- use `mode='lap'` or `method='markov'` only when the user specifically wants a Markov-style or graph-Laplacian interpretation
+
+## Stage 5: Export And Cleanup
+
+Relevant branch-heavy parameters:
+
+- `export_rank_xlsx(..., rank_prefix='rank')`
+- `cleanup(..., del_prediction=False | True, del_2nd_moments=False | True)`
+
+Recommendation:
+
+- export only after ranking keys are final
+- run `cleanup(...)` only after plots or reports no longer depend on `kinetics_heatmap`, fate internals, or cached model fits
+
+## Decision Rule
+
+If the user asks for:
+
+- "the notebook workflow" -> run the default job, but treat zebrafish labels and example genes as worked-example defaults
+- "acceleration or curvature" -> stop after Stage 2
+- "regulators or networks" -> complete Stages 1 to 3, then stop
+- "pseudotime heatmap" or "state graph" -> complete Stages 1 to 4
+- "export ranking tables" -> run the needed ranking stage first, then Stage 5

--- a/skills/dynamo-geneid-convert/SKILL.md
+++ b/skills/dynamo-geneid-convert/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: dynamo-geneid-convert
+description: Convert Ensembl-style gene IDs to gene symbols in `dynamo` with `dynamo.preprocessing.convert2gene_symbol` or `dynamo.preprocessing.convert2symbol`, including human and zebrafish IDs, version-suffix stripping, `AnnData.var_names` updates, and optional preprocessing handoff. Use when adapting `docs/tutorials/notebooks/110_geneid_convert_tutorial.ipynb`, standardizing `adata.var_names`, mapping Ensembl IDs to symbols, or doing identifier cleanup before a `Preprocessor` recipe.
+---
+
+# Dynamo Gene ID Convert
+
+## Goal
+
+Convert Ensembl-style identifiers to gene symbols in a way that another agent can actually rerun: choose the correct conversion path, preserve traceability columns, handle species and version-suffix edge cases, and only hand off to `Preprocessor` after IDs are standardized.
+
+## Quick Workflow
+
+1. Inspect `adata.var_names` or the raw ID list and determine whether the user needs a batch table or an in-place `AnnData` update.
+2. Strip version suffixes such as `.1` into a `query` column before you treat mapping quality as final.
+3. Use `convert2gene_symbol(...)` when you need an explicit mapping table, reproducible merge logic, or non-human species control.
+4. Use `convert2symbol(adata, ...)` only when in-place `AnnData` mutation is the right abstraction and the prefix / `scopes` rules are satisfied.
+5. Keep the original identifier in `adata.var`, set `adata.var_names` from `symbol` only after validating duplicates and missing mappings, and run preprocessing afterward, not before.
+
+## Interface Summary
+
+- `convert2gene_symbol(input_names, scopes='ensembl.gene', ensembl_release=None, species=None, force_rebuild=False)` returns a DataFrame indexed by `query` with at least `symbol` and `_score`.
+- The live source uses vendored `pyensembl` data access, not a remote MyGene batch API.
+- `convert2symbol(adata, scopes=None, subset=True)` updates `adata.var`, adds `query` plus `symbol`, and can rewrite `adata.var_names` in place.
+- `Preprocessor.preprocess_adata(adata, recipe='monocle', tkey=None, experiment_type=None)` is only the downstream handoff. Current source exposes five `recipe` branches:
+  `monocle`, `seurat`, `sctransform`, `pearson_residuals`, `monocle_pearson_residuals`.
+
+Read `references/source-grounding.md` before documenting parameters more narrowly than the notebook does.
+
+## Conversion Path Selection
+
+- Use `convert2gene_symbol(...)` as the default for notebook conversion work.
+  It is the safest path when you need explicit `species`, `ensembl_release`, manual merge logic, or per-ID validation.
+- Use `convert2symbol(adata)` for human or mouse Ensembl-style `adata.var_names` when direct in-place conversion is acceptable.
+- Use `convert2symbol(adata, scopes='ensembl.gene')` for zebrafish or other non-human prefixes if you still want the in-place helper.
+- Do not trust the notebook's generic `scopes` explanation alone.
+  In current source, `convert2gene_symbol` keeps `scopes` only for compatibility, while `convert2symbol` still branches on `scopes` and prefix heuristics.
+
+## Minimal Execution Patterns
+
+For an explicit mapping table and controlled merge:
+
+```python
+import dynamo as dyn
+
+adata = dyn.sample_data.hematopoiesis_raw()
+adata.var["ensembl_id"] = adata.var_names
+adata.var["query"] = adata.var_names.str.split(".").str[0]
+
+mapping = dyn.preprocessing.convert2gene_symbol(
+    adata.var["query"].tolist(),
+    species="human",
+)
+
+adata.var = (
+    adata.var
+    .merge(mapping, left_on="query", right_index=True, how="left")
+    .set_index(adata.var.index)
+)
+
+mapped = adata.var["symbol"].notna()
+adata = adata[:, mapped].copy()
+adata.var_names = adata.var["symbol"].astype(str)
+```
+
+For in-place conversion on supported prefixes:
+
+```python
+import dynamo as dyn
+
+adata = dyn.sample_data.hematopoiesis_raw()
+adata.var["ensembl_id"] = adata.var_names
+dyn.preprocessing.convert2symbol(adata, subset=True)
+```
+
+For zebrafish IDs with version suffixes:
+
+```python
+import dynamo as dyn
+
+result = dyn.preprocessing.convert2gene_symbol(
+    ["ENSDARG00000035558.1"],
+    ensembl_release=77,
+)
+
+# Or, if the user wants in-place AnnData mutation:
+dyn.preprocessing.convert2symbol(adata, scopes="ensembl.gene")
+```
+
+## Optional Preprocess Integration
+
+- Perform gene-ID conversion before preprocessing unless the user explicitly wants to preserve notebook timing.
+- If the user proceeds into preprocessing, default to `recipe='monocle'` unless they ask for a different branch.
+- If the user requests Pearson residuals but still cares about downstream velocity-safe layers, prefer `monocle_pearson_residuals`.
+
+Read `references/preprocess-handoff.md` before choosing a non-default `recipe`.
+
+## Validation
+
+After conversion, check these items:
+
+- `adata.var["query"]` stores the version-stripped identifier actually used for lookup.
+- `adata.var["symbol"]` exists and the mapping rate is acceptable for the dataset.
+- The original ID remains preserved, for example in `adata.var["ensembl_id"]`.
+- `adata.var_names` contains symbols only after duplicate and null handling is explicit.
+- Representative conversions still match live source behavior:
+  `ENSG00000141510 -> TP53` and `ENSDARG00000035558(.1) -> gps2` with `ensembl_release=77`.
+- If preprocessing follows, `Preprocessor.preprocess_adata(..., recipe=...)` should run only after symbol assignment is settled.
+
+## Constraints
+
+- Do not describe conversion as MyGene-backed just because older prose or notebook wording suggests that pattern; current source uses vendored `pyensembl`.
+- Do not assume `convert2symbol(adata)` auto-detects every species. In current source it auto-classifies some human / mouse gene or transcript prefixes, but zebrafish without explicit `scopes` raises.
+- Do not assume the docstring's `ensembl_release` default is authoritative. Current code assigns `77` when the argument is omitted.
+- The first conversion run may install `polars` or download / index Ensembl data, so cold-start execution can be slower than the notebook suggests.
+
+## Resource Map
+
+- Read `references/source-grounding.md` for inspected signatures, live-source behavior, and branch coverage.
+- Read `references/conversion-paths.md` for human vs zebrafish decision rules and `scopes` handling.
+- Read `references/preprocess-handoff.md` for the downstream `recipe` branches.
+- Read `references/source-notebook-map.md` to see which notebook sections were preserved or intentionally dropped.
+- Read `references/compatibility.md` when notebook wording and current source behavior appear to disagree.

--- a/skills/dynamo-geneid-convert/assets/acceptance.json
+++ b/skills/dynamo-geneid-convert/assets/acceptance.json
@@ -1,0 +1,71 @@
+{
+  "version": 1,
+  "skill": "dynamo-geneid-convert",
+  "sample_requests": [
+    "Convert Ensembl gene IDs to symbols in this AnnData before dynamo preprocessing",
+    "Turn the gene ID conversion tutorial into an executable workflow with zebrafish and human examples"
+  ],
+  "required_description_terms": [
+    "dynamo",
+    "convert2gene_symbol",
+    "convert2symbol",
+    "anndata",
+    "preprocessor",
+    "notebooks"
+  ],
+  "required_sections": [
+    "## Goal",
+    "## Quick Workflow",
+    "## Interface Summary",
+    "## Conversion Path Selection",
+    "## Validation",
+    "## Resource Map"
+  ],
+  "required_body_terms": [
+    "convert2gene_symbol",
+    "convert2symbol",
+    "ensembl_release",
+    "species",
+    "scopes",
+    "recipe",
+    "query",
+    "symbol"
+  ],
+  "required_paths": [
+    "references/source-grounding.md",
+    "references/conversion-paths.md",
+    "references/preprocess-handoff.md",
+    "references/source-notebook-map.md",
+    "references/compatibility.md"
+  ],
+  "smoke_commands": [
+    {
+      "name": "human-convert2gene_symbol",
+      "conda_env": "omictest",
+      "env": {
+        "PYTHONPATH": ".",
+        "MPLCONFIGDIR": "/tmp/mpl",
+        "NUMBA_CACHE_DIR": "/tmp/numba"
+      },
+      "command": "${PYTHON} -c \"from dynamo.preprocessing.utils import convert2gene_symbol; df = convert2gene_symbol(['ENSG00000141510']); print(df.loc['ENSG00000141510', 'symbol'])\"",
+      "timeout_seconds": 180,
+      "expect_stdout_contains": [
+        "TP53"
+      ]
+    },
+    {
+      "name": "zebrafish-convert2symbol-with-scopes",
+      "conda_env": "omictest",
+      "env": {
+        "PYTHONPATH": ".",
+        "MPLCONFIGDIR": "/tmp/mpl",
+        "NUMBA_CACHE_DIR": "/tmp/numba"
+      },
+      "command": "${PYTHON} -c \"import numpy as np; import anndata as ad; from dynamo.preprocessing.utils import convert2symbol; adata = ad.AnnData(X=np.ones((1, 1))); adata.var_names = ['ENSDARG00000035558.1']; convert2symbol(adata, scopes='ensembl.gene'); print(adata.var_names[0])\"",
+      "timeout_seconds": 180,
+      "expect_stdout_contains": [
+        "gps2"
+      ]
+    }
+  ]
+}

--- a/skills/dynamo-geneid-convert/references/compatibility.md
+++ b/skills/dynamo-geneid-convert/references/compatibility.md
@@ -1,0 +1,55 @@
+# Compatibility
+
+Use this reference when notebook wording and current source behavior diverge.
+
+## Current Conversion Backend
+
+Prefer the current source truth:
+
+- `dynamo.preprocessing.convert2gene_symbol(...)` uses vendored `pyensembl`
+
+Do not present the skill as if it depends on a generic MyGene batch-query service just because the notebook explains the idea that way.
+
+## `ensembl_release` Drift
+
+Observed mismatch:
+
+- docstring says `ensembl_release=None` defaults to `109`
+- current code assigns `77`
+
+Conservative rule:
+
+- if annotation-build reproducibility matters, always pass `ensembl_release` explicitly
+- do not rely on the docstring default
+
+## Species / Scope Drift
+
+Observed mismatch between the two helpers:
+
+- `convert2gene_symbol(...)` can infer zebrafish from `ENSDARG...`
+- `convert2symbol(adata)` does not auto-select zebrafish scope and raises unless `scopes` is provided
+
+Conservative rule:
+
+- for zebrafish, use `convert2gene_symbol(...)` or call `convert2symbol(adata, scopes='ensembl.gene')`
+
+## Cold-Start Runtime Costs
+
+Observed during local validation:
+
+- the first conversion may install `polars`
+- first use may also download or index the required Ensembl data
+
+Conservative rule:
+
+- warn the user that the first successful run can be slower than later cached runs
+- treat a cold-start delay as normal unless the command actually fails
+
+## Preprocessing Integration
+
+Prefer:
+
+- convert IDs first
+- preprocess second
+
+Do not rename `adata.var_names` after preprocessing unless the user explicitly wants to repair an already-processed object and accepts the downstream risk.

--- a/skills/dynamo-geneid-convert/references/conversion-paths.md
+++ b/skills/dynamo-geneid-convert/references/conversion-paths.md
@@ -1,0 +1,114 @@
+# Conversion Paths
+
+This reference captures the branch-heavy parts of the notebook that are easy to miss if you only read the demonstrated cells.
+
+## Default Choice
+
+Use `convert2gene_symbol(...)` by default when converting notebook logic into a reusable workflow.
+
+Why:
+
+- it exposes `species`, `ensembl_release`, and `force_rebuild`
+- it supports explicit merge and duplicate handling
+- it works for zebrafish auto-detection directly
+- it keeps the lookup table visible instead of mutating `AnnData` immediately
+
+## Path A: Manual Table + Merge
+
+Use when:
+
+- the user wants auditability
+- the dataset may contain duplicate mapped symbols
+- you need a `query` column, mapping-rate check, or null filtering
+- you want explicit `species` or `ensembl_release`
+
+Recommended sequence:
+
+1. Copy original IDs into `adata.var["ensembl_id"]`
+2. Create `adata.var["query"] = adata.var_names.str.split(".").str[0]`
+3. Call `convert2gene_symbol(adata.var["query"].tolist(), ...)`
+4. Merge on `query`
+5. Decide how to handle missing or duplicated `symbol`
+6. Set `adata.var_names` from `symbol`
+
+## Path B: `convert2symbol(adata, ...)`
+
+Use when:
+
+- the user already has an `AnnData`
+- in-place mutation is acceptable
+- the prefix / `scopes` behavior is understood
+
+### Human / Mouse Gene IDs
+
+Current source auto-detects some cases:
+
+- `ENSG...` -> gene scope
+- `ENSMUSG...` -> gene scope
+
+For these, `convert2symbol(adata)` is usually enough.
+
+### Human / Mouse Transcript IDs
+
+Current source also recognizes:
+
+- `ENST...`
+- `ENSMUST...`
+
+For these, `convert2symbol(adata)` auto-selects transcript scope.
+
+### Zebrafish And Other Non-Human Prefixes
+
+Do not rely on `convert2symbol(adata)` without `scopes`.
+
+Observed runtime behavior:
+
+- zebrafish `ENSDARG...` enters conversion mode because IDs start with `ENS`
+- auto-scope detection then fails
+- the helper raises and tells you to pass the correct scope
+
+Recommended fix:
+
+```python
+dyn.preprocessing.convert2symbol(adata, scopes="ensembl.gene")
+```
+
+If the user also cares about annotation-build reproducibility, prefer the manual `convert2gene_symbol(...)` path with explicit `ensembl_release`.
+
+## Version Suffix Handling
+
+The notebook mentions suffix stripping. Current source really does strip version suffixes before lookup:
+
+- `ENSG00000141510.5` is queried as `ENSG00000141510`
+- `ENSDARG00000035558.1` is queried as `ENSDARG00000035558`
+
+Still keep the original versioned ID in `adata.var["ensembl_id"]` when traceability matters.
+
+## Supported Species In Current Source
+
+`convert2gene_symbol(...)` explicitly handles these prefixes:
+
+- `human`
+- `mouse`
+- `rat`
+- `zebrafish`
+- `fly`
+- `chicken`
+- `dog`
+- `pig`
+- `cow`
+- `macaque`
+
+If the prefix is unrecognized, the code warns and defaults to `human`.
+
+## Decision Rule
+
+If the user says only "convert gene IDs to symbols in this AnnData":
+
+- use `convert2symbol(adata)` for human / mouse prefixes
+- use `convert2symbol(adata, scopes="ensembl.gene")` for zebrafish if they want the helper
+- otherwise prefer `convert2gene_symbol(...)` plus explicit merge
+
+If the user says "make it reproducible across annotation builds":
+
+- use `convert2gene_symbol(...)` with explicit `species` and `ensembl_release`

--- a/skills/dynamo-geneid-convert/references/preprocess-handoff.md
+++ b/skills/dynamo-geneid-convert/references/preprocess-handoff.md
@@ -1,0 +1,79 @@
+# Preprocess Handoff
+
+This notebook is mainly about identifier conversion, but the last section hands the result into preprocessing. Use this reference so the generated skill does not freeze that handoff to one notebook path.
+
+## Rule
+
+Finish gene-ID conversion before preprocessing unless the user explicitly asks for historical notebook order.
+
+Why:
+
+- `standardize_adata(...)` inside preprocessing calls the configured gene-name conversion function
+- changing `var_names` after preprocessing can invalidate assumptions in downstream cached results
+- the notebook itself warns that conversion is best done before the main preprocessing pipeline
+
+## Downstream `recipe` Branches
+
+Current source for `Preprocessor.preprocess_adata(...)` dispatches these values:
+
+- `monocle`
+- `seurat`
+- `sctransform`
+- `pearson_residuals`
+- `monocle_pearson_residuals`
+
+## Default Choice
+
+Use `recipe='monocle'` unless the user asks for a different preprocessing objective.
+
+## Branch Summary
+
+### `monocle`
+
+Use when:
+
+- the user wants standard dynamo preprocessing after conversion
+- downstream work includes velocity or vector-field analysis
+
+### `seurat`
+
+Use when:
+
+- the user explicitly wants Seurat-style HVG selection inside the current `Preprocessor`
+
+### `sctransform`
+
+Use when:
+
+- the user explicitly requests sctransform
+- the runtime can support the extra dependencies and preprocessing cost
+
+### `pearson_residuals`
+
+Use when:
+
+- the user mainly wants Pearson-residual feature selection and PCA
+
+### `monocle_pearson_residuals`
+
+Use when:
+
+- the user wants Pearson-residual feature selection and PCA
+- the user still needs monocle-style normalized layers for downstream velocity-safe workflows
+
+## Minimal Handoff Pattern
+
+```python
+from dynamo.preprocessing import Preprocessor
+
+preprocessor = Preprocessor()
+preprocessor.preprocess_adata(adata, recipe="monocle", tkey="time", experiment_type="one-shot")
+```
+
+## Validation After Handoff
+
+At minimum, check:
+
+- `adata.var_names` already reflects the intended symbol space
+- the chosen `recipe` was explicit
+- preprocessing no longer needs to rename genes implicitly

--- a/skills/dynamo-geneid-convert/references/source-grounding.md
+++ b/skills/dynamo-geneid-convert/references/source-grounding.md
@@ -1,0 +1,115 @@
+# Source Grounding
+
+This skill was grounded against live source and runtime inspection instead of notebook prose alone.
+
+## Inspection Notes
+
+Source inspection and empirical checks were performed in a local Python runtime compatible with this repository's dependencies.
+
+## Primary Source Files
+
+Notebook inspected:
+
+- `docs/tutorials/notebooks/110_geneid_convert_tutorial.ipynb`
+
+Code inspected:
+
+- `dynamo/preprocessing/utils.py`
+- `dynamo/preprocessing/Preprocessor.py`
+
+## Inspected Signatures
+
+### `dynamo.preprocessing.convert2gene_symbol`
+
+Observed signature:
+
+```python
+(input_names: List[str], scopes: Optional[List[str]] = 'ensembl.gene',
+ ensembl_release: Optional[int] = None, species: Optional[str] = None,
+ force_rebuild: bool = False) -> pandas.core.frame.DataFrame
+```
+
+Observed behavior from source and runtime:
+
+- returns a DataFrame indexed by `query`
+- writes at least `symbol` and `_score`
+- strips version suffixes before lookup
+- infers `species` from ID prefix when `species` is omitted
+- rebuilds / downloads the Ensembl database when needed
+
+Source-derived species prefixes:
+
+- `ENSG` -> `human`
+- `ENSMUSG` -> `mouse`
+- `ENSRNOG` -> `rat`
+- `ENSDARG` -> `zebrafish`
+- `FBGN` -> `fly`
+- `ENSGALG` -> `chicken`
+- `ENSCAFG` -> `dog`
+- `ENSSSCG` -> `pig`
+- `ENSBTAG` -> `cow`
+- `ENSMMUG` -> `macaque`
+
+Important compatibility finding:
+
+- the docstring says `ensembl_release=None` defaults to `109`
+- the current code assigns `77`
+
+### `dynamo.preprocessing.convert2symbol`
+
+Observed signature:
+
+```python
+(adata: AnnData, scopes: Union[str, Iterable, None] = None, subset=True) -> AnnData
+```
+
+Observed behavior from source and runtime:
+
+- enters conversion mode when all `adata.var_names` start with `ENS` or when `scopes` is provided
+- auto-selects `scopes='ensembl.gene'` for some human / mouse gene prefixes
+- auto-selects `scopes='ensembl.transcript'` for some human / mouse transcript prefixes
+- raises for other prefixes when `scopes` is omitted
+- stores `query` in `adata.var`
+- merges the result of `convert2gene_symbol(...)`
+- rewrites `adata.var.index` to `symbol` when `subset=True`
+
+Notebook-important runtime finding:
+
+- `convert2symbol(adata)` fails on zebrafish `ENSDARG...` IDs without explicit `scopes`
+- `convert2gene_symbol(...)` succeeds on the same IDs because species inference happens there
+
+### `dynamo.preprocessing.Preprocessor.preprocess_adata`
+
+Observed signature:
+
+```python
+(self, adata, recipe='monocle', tkey=None, experiment_type=None) -> None
+```
+
+Source-level `recipe` branches:
+
+- `monocle`
+- `seurat`
+- `sctransform`
+- `pearson_residuals`
+- `monocle_pearson_residuals`
+
+Why the branch list matters here:
+
+- the notebook only uses preprocessing as an optional follow-on
+- the generated skill still documents the current `recipe` branch set so downstream handoff is not notebook-limited
+
+## Empirical Checks Run
+
+Representative empirical checks:
+
+- `convert2gene_symbol(['ENSG00000141510'])` -> `TP53`
+- `convert2gene_symbol(['ENSDARG00000035558.1'], ensembl_release=77)` -> `gps2`
+- `convert2symbol(...)` on human IDs rewrote `adata.var_names` to `['TP53', 'CD3D']`
+- `convert2symbol(...)` on zebrafish without `scopes` raised an exception
+- `convert2symbol(..., scopes='ensembl.gene')` on zebrafish rewrote `adata.var_names` to `['gps2']`
+
+## Human Review Notes
+
+- The notebook frames conversion in MyGene-style service terms, but current executable behavior comes from vendored `pyensembl`.
+- The most important hidden branch in this notebook family is not `method` but the species / prefix path for conversion plus the downstream `recipe` path for preprocessing.

--- a/skills/dynamo-geneid-convert/references/source-notebook-map.md
+++ b/skills/dynamo-geneid-convert/references/source-notebook-map.md
@@ -1,0 +1,88 @@
+# Source Notebook Map
+
+Source notebook:
+`docs/tutorials/notebooks/110_geneid_convert_tutorial.ipynb`
+
+Use this file to trace how the notebook was turned into a reusable skill instead of a summary.
+
+## Notebook Sections To Skill Responsibilities
+
+### 1. Motivation and setup
+
+Notebook role:
+
+- explain why gene-symbol conversion matters
+- establish the two demonstration scenarios
+
+Preserved in the skill:
+
+- `SKILL.md` Goal
+- `SKILL.md` Conversion Path Selection
+- `references/conversion-paths.md`
+
+Dropped from the skill:
+
+- plotting-style setup
+- notebook-only exposition
+
+### 2. Human example
+
+Notebook role:
+
+- show direct conversion on human Ensembl IDs
+- establish the safe `query` / merge / `var_names` update pattern
+
+Preserved in the skill:
+
+- `SKILL.md` Minimal Execution Patterns
+- `SKILL.md` Validation
+- `references/source-grounding.md`
+
+### 3. Zebrafish example
+
+Notebook role:
+
+- show version-suffix stripping
+- show explicit `ensembl_release=77`
+
+Preserved in the skill:
+
+- `SKILL.md` Minimal Execution Patterns
+- `references/conversion-paths.md`
+- `references/compatibility.md`
+
+Source-grounded addition beyond the notebook:
+
+- `convert2symbol(adata)` does not auto-handle zebrafish without explicit `scopes`
+
+### 4. Optional preprocessing follow-on
+
+Notebook role:
+
+- show that ID conversion should happen before preprocessing
+- use a monocle-style `Preprocessor` path
+
+Preserved in the skill:
+
+- `SKILL.md` Optional Preprocess Integration
+- `references/preprocess-handoff.md`
+
+Source-grounded addition beyond the notebook:
+
+- current source exposes five `recipe` branches, not just the single monocle path demonstrated here
+
+## What Was Intentionally Not Carried Over
+
+- long pedagogical explanation
+- raw notebook outputs
+- visualization-only cells
+- any wording that implied the implementation is MyGene-backed instead of current vendored `pyensembl`
+
+## When To Reopen The Notebook
+
+Reopen the notebook only when:
+
+- the user wants cell-by-cell historical reproduction
+- the user wants figure parity
+- a future notebook revision changes the demonstrated IDs or preprocessing handoff
+- source behavior and notebook prose appear to disagree and the difference affects execution

--- a/skills/dynamo-in-silico-perturbation/SKILL.md
+++ b/skills/dynamo-in-silico-perturbation/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: dynamo-in-silico-perturbation
+description: Perform in silico gene perturbation on a dynamo vector-field AnnData to predict cell fate diversion after single or multi-gene activation or suppression, then visualize the results with streamline or quiver plots. Use when running dyn.pd.perturbation, predicting transcription factor perturbation effects, simulating gene knockdown or overexpression in scRNA-seq data, reproducing 502_perturbation_tutorial.ipynb, or choosing among pertubation_method, perturb_mode, and emb_basis branches.
+---
+
+# Dynamo In Silico Gene Perturbation
+
+## Goal
+
+Given a `dynamo` AnnData with a fitted PCA-space vector field and Jacobian, apply expression-level changes to one or more genes and project the resulting velocity shift into a low-dimensional embedding to predict cell fate diversion. Visualize the perturbed trajectories with streamline or cell-wise vector plots.
+
+## Quick Workflow
+
+1. Confirm the input AnnData has `VecFld_pca`, `jacobian_pca`, `X_pca`, and the target embedding (e.g., `X_umap`) precomputed.
+2. Call `dyn.pd.perturbation(adata, genes, expression, emb_basis=...)` to compute the perturbation effect and project it to the embedding space.
+3. Visualize with `dyn.pl.streamline_plot(adata, basis="{emb_basis}_perturbation", ...)`.
+4. Optionally use `dyn.pl.cell_wise_vectors` for quiver-style single-cell vector plots.
+5. Repeat steps 2–4 for each perturbation scenario (single gene, multi-gene, mixed activation/suppression).
+
+## Interface Summary
+
+- `dyn.pd.perturbation(adata, genes, expression=10, perturb_mode='raw', cells=None, zero_perturb_genes_vel=False, pca_key=None, PCs_key=None, pca_mean_key=None, basis='pca', emb_basis='umap', jac_key='jacobian_pca', X_pca=None, delta_Y=None, projection_method='fp', pertubation_method='j_delta_x', J_jv_delta_t=1, delta_t=1, add_delta_Y_key=None, add_transition_key=None, add_velocity_key=None, add_embedding_key=None)` — core perturbation call; writes perturbed embedding and velocity into `adata.obsm`.
+
+  **Note on typo**: the parameter is spelled `pertubation_method` (one `r`) in the source — use that exact spelling.
+
+- `dyn.pl.streamline_plot(adata, basis='umap', ..., method='gaussian', vector='velocity', save_show_or_return='show', **streamline_kwargs)` — after perturbation, call with `basis='{emb_basis}_perturbation'` to visualize diverted cell trajectories.
+
+- `dyn.pl.cell_wise_vectors(adata, basis='umap', ..., vector='velocity', projection='2d', quiver_size=1, quiver_length=None, save_show_or_return='show')` — single-cell quiver vectors; works with perturbation basis.
+
+Read `references/source-grounding.md` for full inspected signatures and storage key evidence.
+
+## Stage Selection
+
+- **Single-gene suppression**: pass one gene string and a single negative value, e.g. `genes='GATA1', expression=[-100]`.
+- **Single-gene activation**: pass one gene string and a single positive value, e.g. `genes='KLF1', expression=[100]`.
+- **Multi-gene simultaneous perturbation**: pass a list of gene names and matching list of expression values.
+- **Mixed activation + suppression**: combine positive and negative values in the expression list.
+- Use `perturb_mode='raw'` (default) to shift expression by the given absolute value. Use `perturb_mode='z_score'` when expression units are z-scores.
+- Use `pertubation_method='j_delta_x'` (default) for the standard linearized Jacobian approach. Use `'f_x_prime'` or `'f_x_prime_minus_f_x_0'` when you want direct vector-field evaluation instead of Jacobian approximation.
+- Restrict perturbation to a cell subset by passing `cells=<index_array>`.
+
+Read `references/branch-selection.md` for details on all `pertubation_method` branches and when to use them.
+
+## Input Contract
+
+- `AnnData` with `VecFld_pca` in `.uns` (PCA-space vector field must already be fitted).
+- `adata.uns['jacobian_pca']` must exist with keys `jacobian`, `regulators`, `effectors`, and `cell_idx`. Run `dyn.vf.jacobian(adata, basis='pca')` first if absent.
+- `adata.uns['PCs']` and `adata.uns['pca_mean']` (or `adata.obsm['X_pca']`) must exist for PCA projection.
+- `adata.obsm['X_{emb_basis}']` must exist for the target embedding projection (default `X_umap`).
+- The hematopoiesis sample dataset (`dyn.sample_data.hematopoiesis()`) already satisfies all these requirements.
+- Gene names in `genes` must appear in both `adata.var_names` and the Jacobian `regulators`/`effectors` arrays.
+
+## Minimal Execution Patterns
+
+### Single-gene suppression
+
+```python
+import dynamo as dyn
+
+adata = dyn.sample_data.hematopoiesis()
+
+gene = "GATA1"
+dyn.pd.perturbation(adata, gene, [-100], emb_basis="umap")
+dyn.pl.streamline_plot(adata, color=["cell_type", gene], basis="umap_perturbation")
+```
+
+### Single-gene activation
+
+```python
+gene = "KLF1"
+dyn.pd.perturbation(adata, gene, [100], emb_basis="umap")
+dyn.pl.streamline_plot(adata, color=["cell_type", gene], basis="umap_perturbation")
+```
+
+### Multi-gene mixed perturbation
+
+```python
+selected_genes = ["SPI1", "GATA1"]
+expr_vals = [-100, -15]
+dyn.pd.perturbation(adata, selected_genes, expr_vals, emb_basis="umap")
+dyn.pl.streamline_plot(adata, color=["cell_type"] + selected_genes, basis="umap_perturbation")
+```
+
+### Restrict to a cell subset
+
+```python
+hsc_idx = dyn.tl.select_cell(adata, "cell_type", "HSC")
+dyn.pd.perturbation(adata, "GATA1", [-100], emb_basis="umap", cells=hsc_idx)
+```
+
+### Custom perturbation method
+
+```python
+# Use direct vector-field evaluation instead of Jacobian linearization
+dyn.pd.perturbation(
+    adata, "GATA1", [-100],
+    emb_basis="umap",
+    pertubation_method="f_x_prime_minus_f_x_0",  # note: one 'r' in 'pertubation'
+)
+```
+
+### Cell-wise quiver visualization
+
+```python
+dyn.pl.cell_wise_vectors(
+    adata,
+    basis="umap_perturbation",
+    color="cell_type",
+    quiver_size=1,
+    save_show_or_return="show",
+)
+```
+
+## Validation
+
+After `dyn.pd.perturbation(adata, genes, expression, emb_basis='umap')`, confirm:
+
+- `adata.obsm['X_umap_perturbation']` exists and has shape `(n_obs, 2)`
+- `adata.obsm['velocity_umap_perturbation']` exists and has shape `(n_obs, 2)`
+- `adata.obsm['j_delta_x_perturbation']` exists (or the key matching your `pertubation_method`)
+- `adata.obsp['perturbation_transition_matrix']` exists (sparse matrix)
+- Terminal log includes: `you can use dyn.pl.streamline_plot(adata, basis='umap_perturbation') to visualize the perturbation vector`
+
+After `dyn.pl.streamline_plot(adata, basis='umap_perturbation')`:
+
+- A matplotlib figure appears with streamlines overlaid on the UMAP perturbation embedding
+- Streamlines show directional bias consistent with the expected cell fate diversion
+
+## Constraints
+
+- Jacobian must cover the perturbed genes: if a gene is not in `adata.uns['jacobian_pca']['regulators']`, the Jacobian row for that gene will be zero and the perturbation will have no effect. Run `dyn.vf.jacobian(adata, regulators=gene_list, effectors=gene_list, basis='pca')` with an explicit gene list if needed.
+- `expression` can be a scalar or a list; if a list, it must be the same length as `genes`.
+- Large absolute expression values (e.g., `±100`) saturate the perturbation in PCA space; they are conventional in the tutorial but not physically bounded.
+- Each `dyn.pd.perturbation` call overwrites `adata.obsm['X_{emb_basis}_perturbation']` and `adata.obsm['velocity_{emb_basis}_perturbation']` for that basis. Save or rename intermediate results between scenarios if needed.
+- The hematopoiesis dataset uses human gene names (all-caps, e.g., `GATA1`). Confirm gene naming convention for non-hematopoiesis datasets.
+
+## Resource Map
+
+- Read `references/source-grounding.md` for full inspected signatures and storage key details.
+- Read `references/branch-selection.md` for `pertubation_method` and `perturb_mode` branch options.
+- Read `references/source-notebook-map.md` to trace `502_perturbation_tutorial.ipynb` sections to skill resources.
+- Read `references/compatibility.md` for known API traps, including the `pertubation_method` typo and Jacobian prerequisite.
+- Use `assets/acceptance.json` for the bounded smoke path used by local acceptance.

--- a/skills/dynamo-in-silico-perturbation/assets/acceptance.json
+++ b/skills/dynamo-in-silico-perturbation/assets/acceptance.json
@@ -1,0 +1,81 @@
+{
+  "version": 1,
+  "skill": "dynamo-in-silico-perturbation",
+  "sample_requests": [
+    "Run in silico gene perturbation on a dynamo AnnData to predict cell fate diversion",
+    "Suppress GATA1 and visualize the effect using dyn.pd.perturbation",
+    "Activate KLF1 and SPI1 together and plot the perturbed trajectories",
+    "Convert 502_perturbation_tutorial.ipynb into a reusable perturbation workflow",
+    "Predict transcription factor perturbation effects on hematopoietic cell fate"
+  ],
+  "required_description_terms": [
+    "dynamo",
+    "perturbation",
+    "cell fate",
+    "gene",
+    "anndata"
+  ],
+  "required_sections": [
+    "## Goal",
+    "## Quick Workflow",
+    "## Interface Summary",
+    "## Stage Selection",
+    "## Minimal Execution Patterns",
+    "## Validation",
+    "## Resource Map"
+  ],
+  "required_body_terms": [
+    "dyn.pd.perturbation",
+    "pertubation_method",
+    "perturb_mode",
+    "emb_basis",
+    "umap_perturbation",
+    "streamline_plot",
+    "jacobian_pca",
+    "j_delta_x_perturbation",
+    "X_umap_perturbation",
+    "velocity_umap_perturbation"
+  ],
+  "required_paths": [
+    "references/source-grounding.md",
+    "references/branch-selection.md",
+    "references/source-notebook-map.md",
+    "references/compatibility.md"
+  ],
+  "smoke_commands": [
+    {
+      "name": "single-gene-perturbation",
+      "conda_env": "omictest",
+      "env": {
+        "MPLBACKEND": "Agg",
+        "MPLCONFIGDIR": "/tmp/mpl",
+        "NUMBA_CACHE_DIR": "/tmp/numba",
+        "PYTHONPATH": "/Users/fernandozeng/Desktop/analysis/dynamo-release"
+      },
+      "command": "${PYTHON} -c \"import dynamo as dyn; adata=dyn.sample_data.hematopoiesis(); dyn.pd.perturbation(adata, 'GATA1', [-100], emb_basis='umap'); print('X_umap_perturbation:', 'X_umap_perturbation' in adata.obsm and adata.obsm['X_umap_perturbation'].shape==(1947,2)); print('velocity_umap_perturbation:', 'velocity_umap_perturbation' in adata.obsm); print('j_delta_x_perturbation:', 'j_delta_x_perturbation' in adata.obsm); print('perturbation_transition_matrix:', 'perturbation_transition_matrix' in adata.obsp)\"",
+      "timeout_seconds": 120,
+      "expect_stdout_contains": [
+        "X_umap_perturbation: True",
+        "velocity_umap_perturbation: True",
+        "j_delta_x_perturbation: True",
+        "perturbation_transition_matrix: True"
+      ]
+    },
+    {
+      "name": "multi-gene-and-custom-keys",
+      "conda_env": "omictest",
+      "env": {
+        "MPLBACKEND": "Agg",
+        "MPLCONFIGDIR": "/tmp/mpl",
+        "NUMBA_CACHE_DIR": "/tmp/numba",
+        "PYTHONPATH": "/Users/fernandozeng/Desktop/analysis/dynamo-release"
+      },
+      "command": "${PYTHON} -c \"import dynamo as dyn; adata=dyn.sample_data.hematopoiesis(); dyn.pd.perturbation(adata, ['SPI1','GATA1'], [-100,-15], emb_basis='umap'); print('multi_gene_ok:', 'X_umap_perturbation' in adata.obsm); dyn.pd.perturbation(adata, 'KLF1', [100], emb_basis='umap', add_embedding_key='X_umap_KLF1_up', add_velocity_key='velocity_umap_KLF1_up'); print('custom_key_ok:', 'X_umap_KLF1_up' in adata.obsm and 'velocity_umap_KLF1_up' in adata.obsm)\"",
+      "timeout_seconds": 120,
+      "expect_stdout_contains": [
+        "multi_gene_ok: True",
+        "custom_key_ok: True"
+      ]
+    }
+  ]
+}

--- a/skills/dynamo-in-silico-perturbation/references/branch-selection.md
+++ b/skills/dynamo-in-silico-perturbation/references/branch-selection.md
@@ -1,0 +1,85 @@
+# Branch Selection
+
+## `pertubation_method` Options
+
+Note: the parameter name is `pertubation_method` (one `r`) in the source — a persistent typo. Always spell it this way when calling the function.
+
+| value | when to use |
+|---|---|
+| `j_delta_x` | **Default and recommended.** Linearizes the perturbation through the Jacobian: `delta_Y = J · (X_perturb - X_wild) · delta_t`. Best for small-to-moderate expression changes where the Jacobian approximation is valid. |
+| `j_x_prime` | Use when you want to evaluate the Jacobian at the absolute perturbed state rather than at the delta. Less common. |
+| `j_jv` | Second-order: `delta_Y = J · (J · delta_X · J_jv_delta_t) · delta_t`. Use when you want to account for the velocity change induced by the perturbation itself. Control time scales with `J_jv_delta_t` and `delta_t`. |
+| `f_x_prime` | Directly evaluates the learned vector field at the perturbed expression coordinates (no Jacobian approximation). Use when the perturbation is large enough that linearization may break down. Requires `VecFld_pca` in `adata.uns`. |
+| `f_x_prime_minus_f_x_0` | Computes the difference in vector field between perturbed and wild-type state: `f(X_perturb) - f(X_wt)`. Preferred over `f_x_prime` when you want the net change in trajectory, not the absolute trajectory. |
+
+## `perturb_mode` Options
+
+| value | when to use |
+|---|---|
+| `raw` | **Default.** Treats `expression` as the absolute gene expression level to set. A value of `100` means "set this gene's expression to 100 in all cells". A value of `-100` is effectively downregulation (note: expression cannot be negative physically; large negative values push cells toward zero). |
+| `z_score` | Treats `expression` as a z-score relative to the population distribution. Internally applies `z_score_inv` to map back to raw units. Use when you want a normalized perturbation that is comparable across genes with different expression scales. |
+
+## Expression Value Conventions
+
+- **Suppression**: use large negative values (e.g., `-100`) to represent strong knockdown. The tutorial uses `-100` as a conventional "full suppression" signal.
+- **Activation**: use large positive values (e.g., `100`) to represent strong overexpression.
+- **Partial perturbation**: use moderate values (e.g., `-15`, `50`) to model weaker effects.
+- **Mixed**: combine in the `expression` list, e.g., `expression=[-100, -15]` for two genes at different suppression levels.
+
+## `emb_basis` Options
+
+Any embedding basis key present in `adata.obsm` can be used. After calling `perturbation(adata, ..., emb_basis='umap')`, the result is stored as `X_umap_perturbation` and `velocity_umap_perturbation`. Visualize with `basis='umap_perturbation'` in plotting functions.
+
+Common options:
+
+- `'umap'` — standard UMAP (default)
+- `'pca'` — PCA space (2D projection)
+- `'tsne'` — t-SNE embedding
+
+## `cells` Subset Option
+
+To restrict the perturbation to a specific cell subset, pass `cells=<index_array>`:
+
+```python
+hsc_idx = dyn.tl.select_cell(adata, "cell_type", "HSC")
+dyn.pd.perturbation(adata, "GATA1", [-100], emb_basis="umap", cells=hsc_idx)
+```
+
+This only perturbs the specified cells; remaining cells retain their unperturbed velocity.
+
+## `zero_perturb_genes_vel` Flag
+
+When `True`, the velocity components of the perturbed genes themselves are zeroed out in the output. Use this when you want to see the downstream (indirect) fate changes without the direct velocity contribution of the perturbed gene.
+
+## `delta_Y` Pre-computed Override
+
+If you have a custom perturbation effect matrix (PCA-space), pass it directly as `delta_Y`. This bypasses the internal Jacobian computation entirely and lets you inject any perturbation signal.
+
+## `streamline_plot` `method` Options
+
+| value | when to use |
+|---|---|
+| `gaussian` | **Default.** Fast Gaussian kernel grid estimation. Sufficient for most perturbation visualizations. |
+| `SparseVFC` | Fits a sparse vector field to the grid. More accurate for complex flow patterns; slower. |
+
+## Saving Perturbation Results Between Scenarios
+
+`dyn.pd.perturbation` always writes to `X_{emb_basis}_perturbation` and `velocity_{emb_basis}_perturbation`. Each subsequent call overwrites the previous result.
+
+To compare multiple scenarios side-by-side, either:
+
+1. Copy results before the next call:
+   ```python
+   import numpy as np
+   gata1_emb = adata.obsm["X_umap_perturbation"].copy()
+   gata1_vel = adata.obsm["velocity_umap_perturbation"].copy()
+   ```
+
+2. Use `add_embedding_key` and `add_velocity_key` to write to custom keys:
+   ```python
+   dyn.pd.perturbation(
+       adata, "GATA1", [-100], emb_basis="umap",
+       add_embedding_key="X_umap_GATA1_down",
+       add_velocity_key="velocity_umap_GATA1_down",
+   )
+   ```

--- a/skills/dynamo-in-silico-perturbation/references/compatibility.md
+++ b/skills/dynamo-in-silico-perturbation/references/compatibility.md
@@ -1,0 +1,54 @@
+# Compatibility Notes
+
+## `pertubation_method` Parameter Typo
+
+The parameter is spelled `pertubation_method` (one `r`) in the source code at `dynamo/prediction/perturbation.py`. This typo has persisted across versions. Using the correctly-spelled `perturbation_method` will be silently ignored as an unexpected keyword argument with `**kwargs`, producing no error but also having no effect — the default `j_delta_x` will be used instead.
+
+Always use:
+```python
+dyn.pd.perturbation(adata, gene, expression, pertubation_method="f_x_prime_minus_f_x_0")
+#                                              ^^ one 'r'
+```
+
+## Jacobian Prerequisite
+
+The default `pertubation_method='j_delta_x'` requires `adata.uns['jacobian_pca']` with keys `jacobian`, `regulators`, `effectors`, and `cell_idx`. This is pre-populated in `dyn.sample_data.hematopoiesis()` but absent on a freshly fitted dataset unless you explicitly run:
+
+```python
+dyn.vf.jacobian(adata, regulators=gene_list, effectors=gene_list, basis='pca')
+```
+
+If a gene is not in `regulators` or `effectors`, its row/column in the Jacobian is zero and the perturbation has no effect. Always verify the gene is covered before interpreting null results.
+
+## `f_x_prime` and `f_x_prime_minus_f_x_0` Prerequisites
+
+These methods bypass the Jacobian and call the vector field function `f` directly. They require `adata.uns['VecFld_pca']` to be present (which it is in the hematopoiesis sample). If the vector field was only fitted on UMAP basis, use `basis='umap'` instead of `basis='pca'`.
+
+## Overwriting Behavior
+
+Each call to `dyn.pd.perturbation` overwrites `adata.obsm['X_{emb_basis}_perturbation']`, `adata.obsm['velocity_{emb_basis}_perturbation']`, and `adata.obsp['perturbation_transition_matrix']`. Previous perturbation results are lost unless:
+
+- Copied manually before the next call
+- Written to custom keys via `add_embedding_key`, `add_velocity_key`, `add_transition_key`
+
+## `expression` Scalar vs. List
+
+When `genes` is a string (single gene), `expression` can be a scalar (`-100`) or a one-element list (`[-100]`). When `genes` is a list, `expression` must be a list of matching length. Mismatched lengths will raise an error inside the function.
+
+## `cell_velocities` Projection Dependency
+
+Internally, `perturbation` calls `dyn.tl.cell_velocities` to project the PCA perturbation to the embedding. This requires `adata.obsp['cosine_transition_matrix']` (or the relevant transition matrix for the chosen `projection_method`). This is present in the hematopoiesis sample but may be absent on custom datasets that skipped the velocity step. Run `dyn.tl.cell_velocities(adata)` first if you see a missing key error during perturbation.
+
+## `streamline_plot` Basis Key Construction
+
+`dyn.pl.streamline_plot(adata, basis='umap_perturbation')` looks for:
+
+- `adata.obsm['X_umap_perturbation']` — coordinates
+- `adata.obsm['velocity_umap_perturbation']` — velocity field
+
+Both keys must exist (written by `perturbation(..., emb_basis='umap')`). If a different `emb_basis` was used, adjust the `basis` parameter accordingly:
+
+```python
+dyn.pd.perturbation(adata, gene, expr, emb_basis="tsne")
+dyn.pl.streamline_plot(adata, basis="tsne_perturbation")
+```

--- a/skills/dynamo-in-silico-perturbation/references/source-grounding.md
+++ b/skills/dynamo-in-silico-perturbation/references/source-grounding.md
@@ -1,0 +1,170 @@
+# Source Grounding
+
+This skill was generated from live code inspection and reviewer-run execution against the dynamo source, not from notebook narration alone.
+
+## Primary Source Files
+
+Notebook inspected:
+
+- `docs/tutorials/notebooks/502_perturbation_tutorial.ipynb`
+
+Code inspected:
+
+- `dynamo/prediction/perturbation.py`
+- `dynamo/plot/scVectorField.py`
+- `dynamo/prediction/__init__.py`
+
+## Inspected Interfaces
+
+### `dyn.pd.perturbation`
+
+Source: `dynamo/prediction/perturbation.py`
+
+Observed signature:
+
+```python
+def perturbation(
+    adata: anndata.AnnData,
+    genes: Union[str, list],
+    expression: Union[float, list] = 10,
+    perturb_mode: str = "raw",
+    cells: Optional[Union[list, np.ndarray]] = None,
+    zero_perturb_genes_vel: bool = False,
+    pca_key: Optional[Union[str, np.ndarray]] = None,
+    PCs_key: Optional[Union[str, np.ndarray]] = None,
+    pca_mean_key: Optional[Union[str, np.ndarray]] = None,
+    basis: str = "pca",
+    emb_basis: str = "umap",
+    jac_key: str = "jacobian_pca",
+    X_pca: Optional[np.ndarray] = None,
+    delta_Y: Optional[np.ndarray] = None,
+    projection_method: str = "fp",
+    pertubation_method: str = "j_delta_x",
+    J_jv_delta_t: float = 1,
+    delta_t: float = 1,
+    add_delta_Y_key: Optional[str] = None,
+    add_transition_key: Optional[str] = None,
+    add_velocity_key: Optional[str] = None,
+    add_embedding_key: Optional[str] = None,
+)
+```
+
+**Important**: The parameter is spelled `pertubation_method` (one `r`, not two) — this is a typo in the source that has persisted. Using `perturbation_method` (correct spelling) will be silently ignored as an unexpected keyword.
+
+Observed `pertubation_method` branches (from source `if/elif` chain):
+
+| value | computation |
+|---|---|
+| `j_delta_x` | `delta_Y = J · (X_perturb_pca - X_pca) · delta_t` — default; linearized change |
+| `j_x_prime` | `delta_Y = J · X_perturb_pca · delta_t` — absolute perturbed state |
+| `j_jv` | `delta_Y = J · (J · delta_X · J_jv_delta_t) · delta_t` — second-order |
+| `f_x_prime` | `delta_Y = f(X_perturb_pca)` — direct vector-field evaluation |
+| `f_x_prime_minus_f_x_0` | `delta_Y = f(X_perturb_pca) - f(X_pca)` — vector-field difference |
+
+Observed `perturb_mode` branches:
+
+| value | behavior |
+|---|---|
+| `raw` | treat `expression` as absolute gene expression value |
+| `z_score` | treat `expression` as z-score; internally applies `z_score_inv` to convert back |
+
+Observed storage keys written by default call (`emb_basis='umap'`, `pertubation_method='j_delta_x'`):
+
+- `adata.obsm['X_umap_perturbation']` — perturbed UMAP coordinates
+- `adata.obsm['velocity_umap_perturbation']` — perturbation velocity in UMAP space
+- `adata.obsm['j_delta_x_perturbation']` — PCA-space perturbation effect matrix
+- `adata.layers['j_delta_x_perturbation']` — gene-space perturbation effects (sparse)
+- `adata.obsp['perturbation_transition_matrix']` — cell transition probability matrix
+
+Custom key overrides via `add_*` parameters:
+
+- `add_delta_Y_key` → overrides the `{pertubation_method}_perturbation` obsm key name
+- `add_transition_key` → overrides `perturbation_transition_matrix`
+- `add_velocity_key` → overrides `velocity_{emb_basis}_perturbation`
+- `add_embedding_key` → overrides `X_{emb_basis}_perturbation`
+
+Internal mechanism (simplified):
+
+```python
+# 1. Retrieve Jacobian
+Js = adata.uns[jac_key]["jacobian"]  # shape: pcs × pcs × cells
+
+# 2. Project perturbed expression to PCA
+X_perturb_pca = expr_to_pca(X_perturb, PCs, means)
+
+# 3. Compute delta_Y (default j_delta_x)
+delta_X = X_perturb_pca - X_pca
+delta_Y[i] = Js[:, :, i] @ delta_X[i] * delta_t
+
+# 4. Project to embedding space via cell_velocities()
+# writes X_{emb_basis}_perturbation and velocity_{emb_basis}_perturbation
+```
+
+### `dyn.pl.streamline_plot`
+
+Source: `dynamo/plot/scVectorField.py`
+
+Observed signature (selected parameters):
+
+```python
+def streamline_plot(
+    adata: AnnData,
+    basis: str = "umap",
+    ekey: str = "M_s",
+    vkey: str = "velocity_S",
+    color: Union[str, List[str]] = "ntr",
+    method: Literal["gaussian", "SparseVFC"] = "gaussian",
+    xy_grid_nums: Tuple[int, int] = (50, 50),
+    cut_off_velocity: bool = True,
+    density: float = 1,
+    linewidth: float = 1,
+    streamline_alpha: float = 1,
+    vector: str = "velocity",
+    inverse: bool = False,
+    save_show_or_return: Literal["save", "show", "return"] = "show",
+    **streamline_kwargs,
+) -> List[Axes]
+```
+
+For perturbation visualization, pass `basis="umap_perturbation"` (or `"{emb_basis}_perturbation"`). The function automatically constructs keys:
+
+- embedding: `adata.obsm["X_" + basis]` → `"X_umap_perturbation"`
+- velocity: `adata.obsm["{vector}_" + basis]` → `"velocity_umap_perturbation"`
+
+Observed `method` branches:
+
+- `gaussian` (default) — Gaussian kernel grid velocity estimation
+- `SparseVFC` — sparse vector field reconstruction for grid
+
+Observed `sort` branches: `"raw"` (default), `"abs"`, `"neg"`
+
+### `dyn.pl.cell_wise_vectors`
+
+Source: `dynamo/plot/scVectorField.py`
+
+Observed signature (selected parameters):
+
+```python
+def cell_wise_vectors(
+    adata: AnnData,
+    basis: str = "umap",
+    vector: str = "velocity",
+    projection: Literal["2d", "3d"] = "2d",
+    quiver_size: Optional[float] = 1,
+    quiver_length: Optional[float] = None,
+    inverse: bool = False,
+    cell_inds: str = "all",
+    save_show_or_return: Literal["save", "show", "return"] = "show",
+) -> Optional[List[Axes]]
+```
+
+Use `basis="umap_perturbation"` to visualize perturbation vectors as quiver arrows per cell.
+
+### `dyn.pl.cell_wise_vectors_3d`
+
+Source: `dynamo/plot/scVectorField.py`
+
+Observed `plot_method` branches:
+
+- `"pv"` — PyVista backend (requires `pyvista` installed)
+- `"matplotlib"` — standard matplotlib 3D axes

--- a/skills/dynamo-in-silico-perturbation/references/source-notebook-map.md
+++ b/skills/dynamo-in-silico-perturbation/references/source-notebook-map.md
@@ -1,0 +1,50 @@
+# Source Notebook Map
+
+Notebook: `docs/tutorials/notebooks/502_perturbation_tutorial.ipynb`
+
+## Section → Skill Resource Mapping
+
+| Notebook section | Skill resource |
+|---|---|
+| Introduction: perturbation method and paper context | `SKILL.md` Goal — demoted to capability framing |
+| Import and data load (`dyn.sample_data.hematopoiesis()`) | `SKILL.md` Input Contract; worked example note |
+| Define gene sets (murine_blood_cells, gran_lineage_genes, erythroid_differentiation) | Demoted — hematopoiesis-specific gene lists, not skill requirements |
+| GATA1 suppression: `perturbation(adata, "GATA1", [-100], emb_basis="umap")` | `SKILL.md` Minimal Execution Patterns — single-gene suppression |
+| SPI1 suppression: `perturbation(adata, "SPI1", [-100], emb_basis="umap")` | `SKILL.md` Minimal Execution Patterns — single-gene suppression (same pattern) |
+| Joint SPI1+GATA1 suppression | `SKILL.md` Minimal Execution Patterns — multi-gene mixed |
+| KLF1 activation: `perturbation(adata, "KLF1", [100], emb_basis="umap")` | `SKILL.md` Minimal Execution Patterns — single-gene activation |
+| Triple GATA1+KLF1+TAL1 activation | `SKILL.md` Minimal Execution Patterns — multi-gene |
+| `dyn.pl.streamline_plot(..., basis="umap_perturbation")` | `SKILL.md` Minimal Execution Patterns + Validation |
+| Biological interpretation (which cells divert where) | Demoted — worked example pedagogy |
+
+## Key Worked-Example Values (Hematopoiesis-Specific)
+
+The following values appear as tutorial defaults. They are hematopoiesis-specific and should not be treated as skill requirements:
+
+- `murine_blood_cells = ["RUN1T1", "HLF", "LMO2", "PRDM5", "PBX1", "ZFP37", "MYCN", "MEIS1"]`
+- `gran_lineage_genes = ["CEBPE", "RUNX1T1", "KLF1", "CEBPA", "FOSB", "JUN", "SPI1", "ZC3HAV1"]`
+- `erythroid_differentiation = ["GATA1", "TAL1", "LMO2", "KLF1", "MYB", "LDB1", "NFE2", "GFI1B", "BCL11A"]`
+- Cell type labels (`"cell_type"` column) and their color scheme
+- Expression saturation values (`-100`, `100`) chosen for hematopoiesis paper figures
+
+## AnnData State at Notebook Load Time
+
+The hematopoiesis sample dataset (`dyn.sample_data.hematopoiesis()`) loads in a fully preprocessed state including:
+
+- `adata.uns['VecFld_pca']` — PCA-space vector field (required)
+- `adata.uns['jacobian_pca']` — PCA-space Jacobian (required for default `j_delta_x` method)
+- `adata.uns['PCs']`, `adata.uns['pca_mean']` — PCA projection matrices (required)
+- `adata.obsm['X_pca']`, `adata.obsm['X_umap']` — embeddings (required)
+- `adata.obsp['cosine_transition_matrix']` — transition matrix (used internally by `cell_velocities`)
+
+## Capability Partition Decision
+
+The notebook contains one tightly coupled job: perturbation + visualization. The perturbation output (`X_{emb_basis}_perturbation`) is directly consumed by the visualization call. Splitting into two skills would create a thin wrapper with no standalone value. A single skill with explicit stage notes is the correct design.
+
+## Cells Not Included in Skill Body
+
+- `%load_ext autoreload` and `%autoreload 2` — notebook-only
+- `dyn.get_all_dependencies_version()` — diagnostic only
+- `dyn.configuration.set_figure_params(...)`, `dyn.pl.style(...)` — style setup
+- `figsize=(4,4)`, `dpi=80` inside `s_kwargs_dict` — notebook display preferences
+- Inline gene set variable definitions that are hematopoiesis-specific

--- a/skills/dynamo-lap-cell-fate-transition/SKILL.md
+++ b/skills/dynamo-lap-cell-fate-transition/SKILL.md
@@ -1,0 +1,216 @@
+---
+name: dynamo-lap-cell-fate-transition
+description: Compute least action paths (LAP) between hematopoietic or general cell types in a dynamo vector-field AnnData, then rank transcription factors by MSD along each path and evaluate predictions via ROC analysis. Use when running dyn.pd.compute_cell_type_transitions, predicting optimal cell fate conversion trajectories, prioritizing transcription factor cocktails for cell reprogramming, or reproducing the 501_lap_tutorial.ipynb workflow on scNT-seq or metabolic-labeling data.
+---
+
+# Dynamo Least Action Path Cell Fate Transition
+
+## Goal
+
+Given a `dynamo` AnnData with a completed vector field and ddhodge potential in UMAP space, compute pairwise least action paths (LAPs) between all requested cell types, extract per-path action and time metrics, rank transcription factors by their mean square displacement (MSD) along each path, and evaluate TF prioritization quality via ROC analysis.
+
+## Quick Workflow
+
+1. Confirm the input AnnData has `VecFld_umap`, `umap_ddhodge_potential`, and a cell type column.
+2. Build a UMAP-basis neighbor graph with `dyn.tl.neighbors(..., basis='umap', result_prefix='umap')`.
+3. Run `dyn.pd.compute_cell_type_transitions(...)` to compute LAPs for all requested cell type pairs.
+4. Persist `transition_graph` and `cells_indices` to disk with `dyn.utils.save_pickle(...)` — this step is long-running.
+5. Load a human TF list with `dyn.sample_data.human_tfs()`.
+6. Extract action and time matrices with `dyn.pd.extract_transition_metrics(...)`.
+7. Plot kinetic heatmaps of gene expression dynamics along selected paths with `dyn.pd.plot_kinetic_heatmap(...)`.
+8. Rank TFs across all transitions with `dyn.pd.analyze_transition_tfs(...)`.
+9. Evaluate TF ranking quality with `dyn.pd.analyze_tf_roc_performance(...)`.
+
+## Interface Summary
+
+- `dyn.tl.neighbors(adata, X_data=None, genes=None, basis='pca', layer=None, n_pca_components=30, n_neighbors=30, method=None, metric='euclidean', metric_kwads=None, cores=1, seed=19491001, result_prefix='', **kwargs)` — build neighbor graph; use `basis='umap', result_prefix='umap'` to create the `X_umap_distances` adjacency needed by LAP.
+- `dyn.pd.compute_cell_type_transitions(adata, cell_types, potential_column='umap_ddhodge_potential', cell_type_column='cell_type', reference_cell_types=None, basis_list=['umap', 'pca'], umap_adj_key='X_umap_distances', pca_adj_key='cosine_transition_matrix', EM_steps=2, top_genes=5, enable_plotting=True, enable_gene_analysis=True, marginal_method='combined', verify_selection=False, manual_cell_indices=None, manual_source_indices=None, manual_target_indices=None)` — core LAP computation; returns `(transition_graph, cells_indices)`.
+- `dyn.pd.extract_transition_metrics(transition_graph, cells_indices_dict, cell_types, transcription_factors, top_tf_genes=10, lap_method='action')` — extract action and time DataFrames per transition pair; returns `(action_df, t_df, tf_genes)`.
+- `dyn.pd.plot_kinetic_heatmap(adata, cells_indices_dict, source_cell_type, target_cell_type, transcription_factors, basis='pca', adj_key='cosine_transition_matrix', figsize=(16, 8), color_map='bwr', font_scale=0.8, scaler=0.6, save_path=None, show_plot=True, return_data=False)` — plot gene expression dynamics along a LAP.
+- `dyn.pd.analyze_kinetic_genes(adata, cells_indices_dict, source_cell_type, target_cell_type, transcription_factors, top_genes=20, basis='pca', adj_key='cosine_transition_matrix')` — rank TFs by MSD along one selected LAP; returns `(ranking_df, top_tfs)`.
+- `dyn.pd.analyze_transition_tfs(transition_graph, human_tfs_names, transitions_config, plot_type='transdifferentiation', known_tfs_dict=None, transition_pmids=None, transition_types=None, total_tf_count=133, transition_color_dict=None, figsize=(8, 5))` — all-in-one: process rankings, build matrix, and plot for one transition type.
+- `dyn.pd.process_all_transition_rankings(transition_graph, human_tfs_names, known_tfs_dict=None)` — step-wise version: add TF and known_TF columns to all transitions; returns `processed_rankings`.
+- `dyn.pd.create_reprogramming_matrix(transition_graph, transitions_config, transition_pmids=None, transition_types=None, total_tf_count=133)` — build normalized priority-score DataFrame; returns `(reprogramming_dict, reprogramming_df)`. **Important**: pass `{}` not `None` for `transition_pmids` and `transition_types` — the current source does not guard against None (see `references/compatibility.md`).
+- `dyn.pd.plot_transition_tf_analysis(reprogramming_df, transition_type='transdifferentiation', figsize=(8, 5), score_threshold=0.8, transition_color_dict=None)` — bar/scatter plot of known TF priority scores per transition type.
+- `dyn.pd.analyze_tf_roc_performance(processed_rankings, transitions_to_include=None, plot_roc=True, roc_plot_params=None)` — compute and optionally plot ROC curve for TF ranking; returns dict with `fpr`, `tpr`, `roc_auc`, `consolidated_df`.
+- `dyn.pd.get_tf_statistics(processed_rankings, reprogramming_df)` — return counts and overlap of TFs; dict with `n_all_tfs`, `n_valid_tfs`, `n_overlap`, `overlap_percentage`.
+- `dyn.utils.save_pickle(file, path)` / `dyn.utils.load_pickle(path)` — persist and restore any Python object; falls back to `cloudpickle` if standard pickle fails.
+
+Read `references/source-grounding.md` for inspected signatures and storage key evidence.
+
+## Stage Selection
+
+- **Stage 1 — LAP computation**: `compute_cell_type_transitions` with `enable_plotting=True, enable_gene_analysis=True`. This is the slow step. Save outputs with `save_pickle` before proceeding.
+- **Stage 2 — Metrics and visualization**: `extract_transition_metrics`, LAP path plotting, action/time heatmaps. Load from pickle if Stage 1 was already run.
+- **Stage 3 — Kinetic heatmaps**: `plot_kinetic_heatmap` and `analyze_kinetic_genes` for specific source–target pairs. Requires `cells_indices` and the adata with fitted vector field.
+- **Stage 4 — TF ranking and ROC**: `analyze_transition_tfs` or the three-step pattern (`process_all_transition_rankings → create_reprogramming_matrix → plot_transition_tf_analysis`), then `analyze_tf_roc_performance`.
+
+Use `analyze_transition_tfs` (all-in-one) for the quickest path. Use the three-step pattern when you need fine-grained control over known TF dictionaries, PMID tables, or plot parameters.
+
+Read `references/stage-selection.md` for details on `marginal_method`, `lap_method`, and `plot_type` branch options.
+
+## Input Contract
+
+- `AnnData` with `VecFld_umap` in `.uns` (vector field must already be fitted).
+- `adata.obs[potential_column]` exists (default `umap_ddhodge_potential`); populated by `dyn.ext.ddhodge`.
+- `adata.obsm['X_umap']` and `adata.obsm['X_pca']` exist.
+- `adata.obsp['cosine_transition_matrix']` exists before calling PCA-basis LAP or kinetic heatmap.
+- A cell type label column in `adata.obs` (default `cell_type`).
+- A transcription factor name list (e.g., from `dyn.sample_data.human_tfs()` for human datasets).
+- The hematopoiesis worked example loads from `dyn.sample_data.hematopoiesis()` — it already includes all required fields.
+
+## Minimal Execution Patterns
+
+### Stage 1 — LAP computation
+
+```python
+import dynamo as dyn
+
+adata = dyn.sample_data.hematopoiesis()
+
+# Build UMAP neighbor graph needed for LAP
+dyn.tl.neighbors(adata, basis="umap", result_prefix="umap")
+
+cell_types = ["HSC", "Meg", "Ery", "Bas", "Mon", "Neu"]
+
+transition_graph, cells_indices = dyn.pd.compute_cell_type_transitions(
+    adata=adata,
+    cell_types=cell_types,
+    reference_cell_types=["HSC"],
+    marginal_method="combined",
+    potential_column="umap_ddhodge_potential",
+    cell_type_column="cell_type",
+    EM_steps=2,
+    top_genes=5,
+    enable_plotting=True,
+    enable_gene_analysis=True,
+)
+
+# Persist — this step is expensive
+dyn.utils.save_pickle(transition_graph, "result/transition_graph.pkl")
+dyn.utils.save_pickle(cells_indices, "result/cells_indices.pkl")
+adata.write("result/adata_labeling_analysis.h5ad")
+```
+
+### Stage 2 — Metrics extraction
+
+```python
+transition_graph = dyn.utils.load_pickle("result/transition_graph.pkl")
+cells_indices = dyn.utils.load_pickle("result/cells_indices.pkl")
+
+human_tfs = dyn.sample_data.human_tfs()
+human_tfs_names = list(human_tfs["Symbol"])
+
+action_df, t_df, tf_genes = dyn.pd.extract_transition_metrics(
+    transition_graph=transition_graph,
+    cells_indices_dict=cells_indices,
+    cell_types=cell_types,
+    transcription_factors=human_tfs_names,
+    top_tf_genes=10,
+    lap_method="action_t",   # 'action' or 'action_t'
+)
+```
+
+### Stage 3 — Kinetic heatmap for one pair
+
+```python
+ranking, top_tfs = dyn.pd.analyze_kinetic_genes(
+    adata=adata,
+    cells_indices_dict=cells_indices,
+    source_cell_type="HSC",
+    target_cell_type="Bas",
+    transcription_factors=human_tfs_names,
+    top_genes=15,
+)
+
+dyn.pd.plot_kinetic_heatmap(
+    adata=adata,
+    cells_indices_dict=cells_indices,
+    source_cell_type="HSC",
+    target_cell_type="Bas",
+    transcription_factors=human_tfs_names,
+    save_path="figures/HSC_to_Bas.png",
+    figsize=(16, 4),
+)
+```
+
+### Stage 4 — TF ranking and ROC
+
+```python
+KNOWN_TFS_DICT = {
+    "HSC->Meg": ["GATA1", "GATA2", "ZFPM1", "GFI1B", "FLI1", "NFE2"],
+    # ... add other transitions
+}
+TRANSITIONS_CONFIG = {
+    "standard": [
+        "HSC->Meg", "HSC->Ery", "HSC->Bas", "HSC->Mon", "HSC->Neu",
+        "Meg->HSC", "Meg->Neu", "Ery->Mon", "Mon->Meg", "Mon->Ery",
+        "Mon->Bas", "Neu->Bas"
+    ],
+    "special": {"Ery->Neu": {"sets": [("TFs1", "TFs_rank1", "Ery->Neu1"), ("TFs2", "TFs_rank2", "Ery->Neu2")]}},
+}
+
+# All-in-one path
+processed_rankings, reprogramming_dict, reprogramming_df = dyn.pd.analyze_transition_tfs(
+    transition_graph=transition_graph,
+    human_tfs_names=human_tfs_names,
+    transitions_config=TRANSITIONS_CONFIG,
+    plot_type="transdifferentiation",
+    known_tfs_dict=KNOWN_TFS_DICT,
+    total_tf_count=133,
+)
+
+# ROC analysis
+roc_results = dyn.pd.analyze_tf_roc_performance(
+    processed_rankings=processed_rankings,
+    plot_roc=True,
+    roc_plot_params={"figsize": (3, 3), "fontsize": 12, "legend_size": 12},
+)
+print("AUC:", roc_results["roc_auc"])
+```
+
+## Validation
+
+After LAP computation, confirm:
+
+- `transition_graph` contains keys for each `A->B` pair
+- Each entry has `LAP_umap` with `prediction` and `action` sub-keys
+- `cells_indices` contains one entry per cell type in `cell_types`
+- Pickle files written successfully to disk
+
+After metrics extraction, confirm:
+
+- `action_df.shape == (len(cell_types), len(cell_types))`
+- `t_df.shape == (len(cell_types), len(cell_types))`
+- `tf_genes` is a dict keyed by transition names
+
+After kinetic heatmap, confirm:
+
+- Output figure file exists at `save_path` if provided
+- `ranking` DataFrame contains MSD scores
+- `top_tfs` list is non-empty
+
+After TF ranking and ROC, confirm:
+
+- `processed_rankings` contains one entry per transition
+- Each entry has `TFs` and `TFs_rank` (or `TFs1`/`TFs2` for special cases)
+- `reprogramming_df` columns include `genes`, `rank`, `transition`, `type`
+- `roc_results['roc_auc']` is a float between 0 and 1
+
+## Constraints
+
+- `compute_cell_type_transitions` requires `VecFld_umap` and `umap_ddhodge_potential` to be precomputed.
+- Run `dyn.tl.neighbors(adata, basis='umap', result_prefix='umap')` before `compute_cell_type_transitions`; it creates `adata.obsp['X_umap_distances']` required for UMAP-basis LAP.
+- The `EM_steps` parameter controls the number of iterative optimization rounds; lower values (1–2) are faster for smoke paths; default `2` is used in the tutorial.
+- Do not treat the hematopoiesis cell type labels, KNOWN_TFS_DICT, or TRANSITION_PMIDS dicts as required skill inputs — they are hematopoiesis-specific worked example parameters.
+- The `transitions_config['special']` key handles transitions with two alternative known TF sets (e.g., `Ery->Neu`). Define it explicitly if your dataset has such ambiguity.
+- `dyn.pd.plot_kinetic_heatmap` is a prediction module function distinct from `dyn.pl.kinetic_heatmap`; they have different signatures and purposes.
+- Set `enable_gene_analysis=True` (default) whenever TF prioritization or kinetic heatmaps are needed; with `enable_gene_analysis=False`, `gtraj` and `ranking` are absent from `transition_graph`, causing `process_all_transition_rankings` to fail and `extract_transition_metrics` to skip TF extraction with a logged error.
+
+## Resource Map
+
+- Read `references/stage-selection.md` when choosing `marginal_method`, `lap_method`, or `plot_type`.
+- Read `references/source-grounding.md` for full inspected signatures and storage key evidence.
+- Read `references/source-notebook-map.md` to trace `501_lap_tutorial.ipynb` sections to skill resources.
+- Read `references/compatibility.md` when encountering API name mismatches or missing attributes.
+- Use `assets/acceptance.json` for the bounded smoke paths used by local acceptance.

--- a/skills/dynamo-lap-cell-fate-transition/assets/acceptance.json
+++ b/skills/dynamo-lap-cell-fate-transition/assets/acceptance.json
@@ -1,0 +1,82 @@
+{
+  "version": 1,
+  "skill": "dynamo-lap-cell-fate-transition",
+  "sample_requests": [
+    "Run least action path analysis between hematopoietic cell types using dynamo",
+    "Compute pairwise LAP transitions and prioritize transcription factors with dyn.pd.compute_cell_type_transitions",
+    "Predict optimal cell fate conversion paths and rank TF cocktails using dynamo LAP on scNT-seq AnnData",
+    "Convert 501_lap_tutorial.ipynb into a reusable LAP cell fate transition workflow"
+  ],
+  "required_description_terms": [
+    "dynamo",
+    "least action path",
+    "cell fate",
+    "transcription factor",
+    "anndata"
+  ],
+  "required_sections": [
+    "## Goal",
+    "## Quick Workflow",
+    "## Interface Summary",
+    "## Stage Selection",
+    "## Minimal Execution Patterns",
+    "## Validation",
+    "## Resource Map"
+  ],
+  "required_body_terms": [
+    "compute_cell_type_transitions",
+    "extract_transition_metrics",
+    "plot_kinetic_heatmap",
+    "analyze_transition_tfs",
+    "analyze_tf_roc_performance",
+    "process_all_transition_rankings",
+    "save_pickle",
+    "umap_ddhodge_potential",
+    "marginal_method",
+    "EM_steps"
+  ],
+  "required_paths": [
+    "references/source-grounding.md",
+    "references/stage-selection.md",
+    "references/source-notebook-map.md",
+    "references/compatibility.md"
+  ],
+  "smoke_commands": [
+    {
+      "name": "lap-core-and-metrics",
+      "conda_env": "omictest",
+      "env": {
+        "MPLBACKEND": "Agg",
+        "MPLCONFIGDIR": "/tmp/mpl",
+        "NUMBA_CACHE_DIR": "/tmp/numba",
+        "PYTHONPATH": "/Users/fernandozeng/Desktop/analysis/dynamo-release"
+      },
+      "command": "${PYTHON} -c \"import dynamo as dyn; adata=dyn.sample_data.hematopoiesis(); dyn.tl.neighbors(adata, basis='umap', result_prefix='umap'); cell_types=['HSC','Meg']; transition_graph, cells_indices = dyn.pd.compute_cell_type_transitions(adata=adata, cell_types=cell_types, reference_cell_types=['HSC'], marginal_method='combined', potential_column='umap_ddhodge_potential', cell_type_column='cell_type', EM_steps=1, top_genes=3, enable_plotting=False, enable_gene_analysis=False); human_tfs=dyn.sample_data.human_tfs(); human_tfs_names=list(human_tfs['Symbol']); action_df, t_df, tf_genes=dyn.pd.extract_transition_metrics(transition_graph=transition_graph, cells_indices_dict=cells_indices, cell_types=cell_types, transcription_factors=human_tfs_names, top_tf_genes=3, lap_method='action_t'); print('transition_keys_ok:', 'HSC->Meg' in transition_graph and 'Meg->HSC' in transition_graph); print('action_df_shape:', action_df.shape); print('t_df_shape:', t_df.shape); print('cells_indices_ok:', 'HSC' in cells_indices and 'Meg' in cells_indices); print('umap_distances_ok:', 'umap_distances' in adata.obsp)\"",
+      "timeout_seconds": 600,
+      "expect_stdout_contains": [
+        "transition_keys_ok: True",
+        "action_df_shape: (2, 2)",
+        "t_df_shape: (2, 2)",
+        "cells_indices_ok: True",
+        "umap_distances_ok: True"
+      ]
+    },
+    {
+      "name": "tf-ranking-and-roc",
+      "conda_env": "omictest",
+      "env": {
+        "MPLBACKEND": "Agg",
+        "MPLCONFIGDIR": "/tmp/mpl",
+        "NUMBA_CACHE_DIR": "/tmp/numba",
+        "PYTHONPATH": "/Users/fernandozeng/Desktop/analysis/dynamo-release"
+      },
+      "command": "${PYTHON} -c \"import dynamo as dyn; adata=dyn.sample_data.hematopoiesis(); dyn.tl.neighbors(adata, basis='umap', result_prefix='umap'); cell_types=['HSC','Meg']; transition_graph, cells_indices = dyn.pd.compute_cell_type_transitions(adata=adata, cell_types=cell_types, reference_cell_types=['HSC'], marginal_method='combined', potential_column='umap_ddhodge_potential', cell_type_column='cell_type', EM_steps=1, top_genes=3, enable_plotting=False, enable_gene_analysis=True); human_tfs=dyn.sample_data.human_tfs(); human_tfs_names=list(human_tfs['Symbol']); KNOWN_TFS={'HSC->Meg':['GATA1','GATA2'],'Meg->HSC':['HLF','MEIS1']}; processed_rankings=dyn.pd.process_all_transition_rankings(transition_graph, human_tfs_names, KNOWN_TFS); TRANSITIONS_CONFIG={'standard':['HSC->Meg','Meg->HSC'],'special':{}}; reprogramming_dict, reprogramming_df=dyn.pd.create_reprogramming_matrix(transition_graph=transition_graph, transitions_config=TRANSITIONS_CONFIG, transition_pmids={}, transition_types={}, total_tf_count=133); roc_results=dyn.pd.analyze_tf_roc_performance(processed_rankings=processed_rankings, plot_roc=False); print('processed_rankings_ok:', len(processed_rankings)>=2); print('reprogramming_df_ok:', set(['genes','rank','transition','type']).issubset(reprogramming_df.columns)); print('roc_auc_ok:', 0.0 <= roc_results['roc_auc'] <= 1.0)\"",
+      "timeout_seconds": 600,
+      "expect_stdout_contains": [
+        "processed_rankings_ok: True",
+        "reprogramming_df_ok: True",
+        "roc_auc_ok: True"
+      ]
+    }
+  ]
+}

--- a/skills/dynamo-lap-cell-fate-transition/references/compatibility.md
+++ b/skills/dynamo-lap-cell-fate-transition/references/compatibility.md
@@ -1,0 +1,71 @@
+# Compatibility Notes
+
+## API Changes in dynamo 1.4.2+
+
+- `compute_cell_type_transitions` was introduced in dynamo 1.4.2 as a high-level wrapper that replaces manual cell-index selection and individual `dyn.pd.least_action` calls. Earlier versions required iterating over cell type pairs manually. Do not use the old per-pair `least_action` pattern unless the installed version predates 1.4.2.
+
+## `dyn.pd.plot_kinetic_heatmap` vs `dyn.pl.kinetic_heatmap`
+
+Two functions with similar names exist:
+
+- `dyn.pd.plot_kinetic_heatmap(adata, cells_indices_dict, source_cell_type, target_cell_type, ...)` — prediction module; takes cell type names and a cells_indices dict; computes and plots kinetics along a LAP.
+- `dyn.pl.kinetic_heatmap(adata, genes, mode=..., basis=..., tkey=..., ...)` — plot module; takes a gene list and plot mode; used for ddhodge pseudotime and vector-field heatmaps.
+
+These are not interchangeable. The LAP tutorial uses `dyn.pd.plot_kinetic_heatmap`.
+
+## `extract_transition_metrics` `lap_method` Default
+
+- Default is `lap_method='action'` in the function signature.
+- The tutorial uses `lap_method='action_t'` to also extract transition time (hours).
+- If only action is needed, omit the argument; if time is needed, set `lap_method='action_t'` explicitly.
+
+## `create_reprogramming_matrix` Null Safety Bug
+
+`create_reprogramming_matrix` calls `transition_pmids.get(...)` and `transition_types.get(...)` without a None guard, despite the signature declaring `transition_pmids=None` and `transition_types=None` as defaults. This raises `AttributeError: 'NoneType' object has no attribute 'get'` when either argument is omitted.
+
+**Workaround**: always pass empty dicts explicitly:
+
+```python
+reprogramming_dict, reprogramming_df = dyn.pd.create_reprogramming_matrix(
+    transition_graph=transition_graph,
+    transitions_config=TRANSITIONS_CONFIG,
+    transition_pmids={},    # must be {} not None
+    transition_types={},    # must be {} not None
+    total_tf_count=133,
+)
+```
+
+## `cloudpickle` Dependency for Pickle
+
+`dyn.utils.save_pickle` falls back to `cloudpickle` when standard `pickle` fails (e.g., for lambda functions or complex objects embedded in the GeneTrajectory). Ensure `cloudpickle` is installed in the target environment if `save_pickle` raises a fallback warning.
+
+## `umap_ddhodge_potential` Availability
+
+The `umap_ddhodge_potential` column is written by `dyn.ext.ddhodge(adata, basis='umap', ...)`. It is pre-populated in `dyn.sample_data.hematopoiesis()` but will be missing on a freshly computed conventional dataset. Compute it with:
+
+```python
+dyn.ext.ddhodge(adata, basis='umap', sampling_method='velocity')
+```
+
+before calling `compute_cell_type_transitions`.
+
+## `cosine_transition_matrix` Availability
+
+`adata.obsp['cosine_transition_matrix']` is written during `dyn.tl.cell_velocities(adata, basis='pca', ...)`. It is present in the pre-processed hematopoiesis sample but may be absent on a freshly built dataset. Ensure it exists before calling `plot_kinetic_heatmap` or `analyze_kinetic_genes` with `adj_key='cosine_transition_matrix'`.
+
+## `enable_gene_analysis` and `gtraj` Availability
+
+When `enable_gene_analysis=False` is passed to `compute_cell_type_transitions`, the `gtraj` GeneTrajectory object and `ranking` DataFrame are NOT added to `transition_graph[name]`. This means:
+
+- `extract_transition_metrics` will log `Error processing <transition>: 'gtraj'` for each pair but still returns the action and time DataFrames correctly.
+- `process_all_transition_rankings` will fail because it reads `transition_graph[name]['ranking']`.
+
+**Rule**: Use `enable_gene_analysis=True` (the default) whenever TF prioritization, kinetic heatmaps, or ROC analysis are needed. Use `enable_gene_analysis=False` only when you want action/time matrices but no TF analysis.
+
+## `enable_plotting=False` for Headless Runs
+
+Set `enable_plotting=False` in `compute_cell_type_transitions` when running in a headless or non-interactive environment to suppress matplotlib display calls that may block execution.
+
+## `EM_steps` and Runtime
+
+`EM_steps=2` is the tutorial default. For datasets with many cell types or large cell counts, each EM step substantially increases runtime. On the hematopoiesis dataset with 6 cell types and EM_steps=2, the full `compute_cell_type_transitions` call can take tens of minutes. Reduce to `EM_steps=1` for exploratory runs.

--- a/skills/dynamo-lap-cell-fate-transition/references/source-grounding.md
+++ b/skills/dynamo-lap-cell-fate-transition/references/source-grounding.md
@@ -1,0 +1,403 @@
+# Source Grounding
+
+This skill was generated from live code inspection of the dynamo source and the 501_lap_tutorial.ipynb notebook.
+
+## Primary Source Files
+
+Notebook inspected:
+
+- `docs/tutorials/notebooks/501_lap_tutorial.ipynb`
+
+Code inspected:
+
+- `dynamo/prediction/least_action_path.py`
+- `dynamo/prediction/_tf_eval.py`
+- `dynamo/tools/connectivity.py`
+- `dynamo/tools/utils.py`
+- `dynamo/utils.py`
+
+## Inspected Interfaces
+
+### `dyn.pd.compute_cell_type_transitions`
+
+Source: `dynamo/prediction/least_action_path.py`
+
+Observed signature:
+
+```python
+def compute_cell_type_transitions(
+    adata,
+    cell_types,
+    potential_column='umap_ddhodge_potential',
+    cell_type_column='cell_type',
+    reference_cell_types=None,
+    basis_list=['umap', 'pca'],
+    umap_adj_key='X_umap_distances',
+    pca_adj_key='cosine_transition_matrix',
+    EM_steps=2,
+    top_genes=5,
+    enable_plotting=True,
+    enable_gene_analysis=True,
+    marginal_method='combined',
+    verify_selection=False,
+    manual_cell_indices=None,
+    manual_source_indices=None,
+    manual_target_indices=None
+)
+```
+
+Observed `marginal_method` branches:
+
+- `combined` — default; integrates distance, degree, and potential
+- `distance` — selects by spatial distance to attractor
+- `degree` — selects by graph degree in neighbor graph
+- `potential` — selects by ddhodge potential value
+
+Returns: `(transition_graph, cells_indices_dict)`
+
+Storage in `transition_graph[name]`:
+
+- `LAP_umap`: dict with `prediction` (list of arrays) and `action` (list of floats)
+- `LAP_pca`: dict with `prediction` and `action`
+- `lap_results`: dict with basis-specific LAP objects
+- `ranking`: DataFrame with gene MSD rankings (column `all`)
+- `gtraj`: GeneTrajectory object
+- `top_genes`: list of top dynamic gene names
+
+### `dyn.pd.extract_transition_metrics`
+
+Source: `dynamo/prediction/least_action_path.py`
+
+Observed signature:
+
+```python
+def extract_transition_metrics(
+    transition_graph,
+    cells_indices_dict,
+    cell_types,
+    transcription_factors,
+    top_tf_genes=10,
+    lap_method='action'
+)
+```
+
+Observed `lap_method` branches:
+
+- `action` — extract only action values
+- `action_t` — extract both action and transition time (used in the hematopoiesis tutorial)
+
+Returns: `(action_df, t_df, tf_genes_results)`
+
+- `action_df`: N×N DataFrame of action values (NaN for missing transitions)
+- `t_df`: N×N DataFrame of LAP integration times
+- `tf_genes_results`: dict keyed by transition name
+
+### `dyn.pd.plot_kinetic_heatmap`
+
+Source: `dynamo/prediction/least_action_path.py`
+
+Observed signature:
+
+```python
+def plot_kinetic_heatmap(
+    adata,
+    cells_indices_dict,
+    source_cell_type,
+    target_cell_type,
+    transcription_factors,
+    basis='pca',
+    adj_key='cosine_transition_matrix',
+    figsize=(16, 8),
+    color_map='bwr',
+    font_scale=0.8,
+    scaler=0.6,
+    save_path=None,
+    show_plot=True,
+    return_data=False
+)
+```
+
+Note: This is `dyn.pd.plot_kinetic_heatmap` (prediction module), distinct from `dyn.pl.kinetic_heatmap` (plot module), which has a completely different signature.
+
+### `dyn.pd.analyze_kinetic_genes`
+
+Source: `dynamo/prediction/least_action_path.py`
+
+Observed signature:
+
+```python
+def analyze_kinetic_genes(
+    adata,
+    cells_indices_dict,
+    source_cell_type,
+    target_cell_type,
+    transcription_factors,
+    top_genes=20,
+    basis='pca',
+    adj_key='cosine_transition_matrix'
+)
+```
+
+Returns: `(ranking_df, top_tfs_list)`
+
+- `ranking_df`: DataFrame with MSD scores and TF flag columns
+- Internally calls `dyn.tl.rank_genes(adata, 'traj_msd')`
+
+### `dyn.pd.analyze_transition_tfs`
+
+Source: `dynamo/prediction/_tf_eval.py`
+
+Observed signature:
+
+```python
+def analyze_transition_tfs(
+    transition_graph,
+    human_tfs_names,
+    transitions_config,
+    plot_type='transdifferentiation',
+    known_tfs_dict=None,
+    transition_pmids=None,
+    transition_types=None,
+    total_tf_count=133,
+    transition_color_dict=None,
+    figsize=(8, 5)
+)
+```
+
+Observed `plot_type` branches:
+
+- `development`
+- `reprogramming`
+- `transdifferentiation`
+
+Returns: `(processed_rankings, reprogramming_dict, reprogramming_df)`
+
+### `dyn.pd.process_all_transition_rankings`
+
+Source: `dynamo/prediction/_tf_eval.py`
+
+Observed signature:
+
+```python
+def process_all_transition_rankings(
+    transition_graph,
+    human_tfs_names,
+    known_tfs_dict=None
+)
+```
+
+Writes into `transition_graph[name]`:
+
+- `TFs`: boolean array marking which genes are TFs
+- `TFs_rank`: rank position array
+- `TFs1`, `TFs2`, `TFs_rank1`, `TFs_rank2` for `Ery->Neu` special case
+
+Returns: `processed_rankings` dict
+
+### `dyn.pd.create_reprogramming_matrix`
+
+Source: `dynamo/prediction/_tf_eval.py`
+
+Observed signature:
+
+```python
+def create_reprogramming_matrix(
+    transition_graph,
+    transitions_config,
+    transition_pmids=None,
+    transition_types=None,
+    total_tf_count=133
+)
+```
+
+`transitions_config` structure:
+
+```python
+{
+    "standard": ["HSC->Meg", ...],   # processed with TFs/TFs_rank
+    "special": {
+        "Ery->Neu": {
+            "sets": [("TFs1", "TFs_rank1", "Ery->Neu1"), ("TFs2", "TFs_rank2", "Ery->Neu2")]
+        }
+    }
+}
+```
+
+`reprogramming_df` columns: `genes`, `rank` (normalized 0–1 as priority score), `transition`, `type`
+
+### `dyn.pd.plot_transition_tf_analysis`
+
+Source: `dynamo/prediction/_tf_eval.py`
+
+Observed signature:
+
+```python
+def plot_transition_tf_analysis(
+    reprogramming_df,
+    transition_type='transdifferentiation',
+    figsize=(8, 5),
+    score_threshold=0.8,
+    transition_color_dict=None
+)
+```
+
+Default color dict: `{"development": "#2E3192", "reprogramming": "#EC2227", "transdifferentiation": "#B9519E"}`
+
+Returns: `(fig, ax)` tuple
+
+### `dyn.pd.analyze_tf_roc_performance`
+
+Source: `dynamo/prediction/_tf_eval.py`
+
+Observed signature:
+
+```python
+def analyze_tf_roc_performance(
+    processed_rankings,
+    transitions_to_include=None,
+    plot_roc=True,
+    roc_plot_params=None
+)
+```
+
+Returns dict keys: `consolidated_df`, `fpr`, `tpr`, `roc_auc`, `performance_summary`
+
+### `dyn.pd.consolidate_processed_rankings`
+
+Source: `dynamo/prediction/_tf_eval.py`
+
+Observed signature:
+
+```python
+def consolidate_processed_rankings(
+    processed_rankings,
+    transitions_to_include=None
+)
+```
+
+Adds `source` column for transition of origin; returns concatenated DataFrame.
+
+### `dyn.pd.calculate_priority_scores_from_consolidated`
+
+Source: `dynamo/prediction/_tf_eval.py`
+
+Observed signature:
+
+```python
+def calculate_priority_scores_from_consolidated(consolidated_df)
+```
+
+Priority score formula: `1 - (rank_position / reference_size)`. Adds `priority_score` column.
+
+### `dyn.pd.plot_roc_curve`
+
+Source: `dynamo/prediction/_tf_eval.py`
+
+Observed signature:
+
+```python
+def plot_roc_curve(
+    y_true,
+    y_scores,
+    figsize=(4, 4),
+    fontsize=12,
+    linewidth=1.5,
+    roc_color='darkorange',
+    diagonal_color='navy',
+    title=None,
+    legend_size=12,
+    hide_zero_ticks=True,
+    return_fig=False
+)
+```
+
+Returns: `(fpr, tpr, roc_auc)` by default, or matplotlib axes if `return_fig=True`.
+
+### `dyn.pd.get_tf_statistics`
+
+Source: `dynamo/prediction/_tf_eval.py`
+
+Observed signature:
+
+```python
+def get_tf_statistics(processed_rankings, reprogramming_df)
+```
+
+Returns dict: `n_all_tfs`, `n_valid_tfs`, `n_overlap`, `overlap_percentage`, `all_tfs`, `valid_tfs`, `overlap_tfs`
+
+### `dyn.tl.neighbors`
+
+Source: `dynamo/tools/connectivity.py`
+
+Observed signature:
+
+```python
+def neighbors(
+    adata,
+    X_data=None,
+    genes=None,
+    basis='pca',
+    layer=None,
+    n_pca_components=30,
+    n_neighbors=30,
+    method=None,
+    metric='euclidean',
+    metric_kwads=None,
+    cores=1,
+    seed=19491001,
+    result_prefix='',
+    **kwargs
+)
+```
+
+With `basis='umap', result_prefix='umap'`, writes:
+
+- `adata.obsp['umap_connectivities']`
+- `adata.obsp['umap_distances']`
+- `adata.uns['umap_neighbors']`
+
+The LAP tutorial calls `neighbors(adata, basis='umap', result_prefix='umap')` to create `X_umap_distances` required by `compute_cell_type_transitions`.
+
+Observed `method` branches when autoselected:
+
+- `kd_tree` (default for small/moderate datasets)
+- `ball_tree`
+- `brute`
+- `umap` (UMAP graph)
+
+### `dyn.tl.select_cell`
+
+Source: `dynamo/tools/utils.py`
+
+Observed signature:
+
+```python
+def select_cell(
+    adata,
+    grp_keys,
+    grps,
+    presel=None,
+    mode='union',
+    output_format='index'
+)
+```
+
+Observed branches:
+
+- `mode`: `union`, `intersection`
+- `output_format`: `index`, `mask`
+
+Returns: numpy array of cell indices or boolean mask.
+
+### `dyn.utils.save_pickle` / `dyn.utils.load_pickle`
+
+Source: `dynamo/utils.py`
+
+Observed signatures:
+
+```python
+def save_pickle(file, path)
+def load_pickle(path)
+```
+
+Falls back to `cloudpickle` if standard `pickle` fails. Used to persist `transition_graph` (complex object graph with LAP metadata and GeneTrajectory objects).

--- a/skills/dynamo-lap-cell-fate-transition/references/source-notebook-map.md
+++ b/skills/dynamo-lap-cell-fate-transition/references/source-notebook-map.md
@@ -1,0 +1,58 @@
+# Source Notebook Map
+
+Notebook: `docs/tutorials/notebooks/501_lap_tutorial.ipynb`
+
+## Section → Skill Resource Mapping
+
+| Notebook section | Skill resource |
+|---|---|
+| Introduction: LAP method and hematopoiesis background | `SKILL.md` Goal; biology demoted to worked example |
+| Import and data load (`dyn.sample_data.hematopoiesis()`) | `SKILL.md` Minimal Execution Patterns — Stage 1 |
+| Compute neighbor graph (`dyn.tl.neighbors`) | `SKILL.md` Interface Summary; `references/source-grounding.md` |
+| Run pairwise LAP (`compute_cell_type_transitions`) | `SKILL.md` Stage 1 pattern; `references/stage-selection.md` |
+| Cell attractor scatter plot | Display-only; demoted from skill body |
+| Save/load pickle (`save_pickle`, `load_pickle`) | `SKILL.md` Stage 1 constraint note |
+| Visualize LAP paths on UMAP streamline | Visualization code; demoted from skill body |
+| LAP time bar chart (developmental lineages) | `SKILL.md` Stage 2 pattern; worked example only |
+| Action and time heatmaps | `SKILL.md` Stage 2 validation checks |
+| Kinetic heatmap (`plot_kinetic_heatmap`) | `SKILL.md` Stage 3 pattern; `references/source-grounding.md` |
+| `analyze_kinetic_genes` TF ranking | `SKILL.md` Stage 3 pattern |
+| `KNOWN_TFS_DICT`, `TRANSITIONS_CONFIG` | `SKILL.md` Stage 4 pattern; note: hematopoiesis-specific |
+| `analyze_transition_tfs` (all-in-one) | `SKILL.md` Stage 4 pattern; `references/stage-selection.md` |
+| Three-step pattern (process → matrix → plot) | `SKILL.md` Stage 4 pattern; `references/stage-selection.md` |
+| ROC curve analysis (`analyze_tf_roc_performance`) | `SKILL.md` Stage 4 pattern; `references/source-grounding.md` |
+| Custom ROC plot (`plot_roc_curve`) | `references/source-grounding.md` |
+| `get_tf_statistics` | `references/source-grounding.md` |
+
+## Key Worked-Example Values (Hematopoiesis-Specific)
+
+The following values appear as tutorial defaults. They are hematopoiesis-specific and should not be treated as skill requirements:
+
+- `cell_types = ["HSC", "Meg", "Ery", "Bas", "Mon", "Neu"]`
+- `potential_column = "umap_ddhodge_potential"`
+- `cell_type_column = "cell_type"`
+- `KNOWN_TFS_DICT` — literature-curated TF lists per hematopoietic transition
+- `TRANSITION_PMIDS` — PubMed IDs specific to hematopoiesis literature
+- `TRANSITION_TYPES` — classification as development / reprogramming / transdifferentiation
+- `total_tf_count = 133` — number of detectable human TFs in this dataset
+- `human_tfs_names` — from `dyn.sample_data.human_tfs()`
+
+## Notebook Cells Not Included in Skill Body
+
+- Inline matplotlib cell scatter plots for attractor visualization
+- Commented-out load cells for restarting a session
+- `%matplotlib inline` magic commands
+- Direct `dyn.configuration.set_pub_style(...)` style-setting calls
+- Inline LAP path visualization (`plot_lap` helper function)
+- Print statements for intermediate transition names
+
+## AnnData State at Notebook Load Time
+
+The hematopoiesis sample dataset (`dyn.sample_data.hematopoiesis()`) loads in a fully preprocessed state:
+
+- `obs`: includes `cell_type`, `umap_ddhodge_potential`, `umap_ddhodge_div`, and many computed columns
+- `uns`: includes `VecFld_pca`, `VecFld_umap`, `neighbors`, `grid_velocity_umap`, etc.
+- `obsm`: includes `X_pca`, `X_umap`, `velocity_pca`, `velocity_umap`, etc.
+- `obsp`: includes `cosine_transition_matrix`, `connectivities`, `distances`, etc.
+
+The `neighbors(adata, basis='umap', result_prefix='umap')` call adds `umap_connectivities` and `umap_distances` to `obsp`, which are required by the UMAP-basis LAP computation.

--- a/skills/dynamo-lap-cell-fate-transition/references/stage-selection.md
+++ b/skills/dynamo-lap-cell-fate-transition/references/stage-selection.md
@@ -1,0 +1,101 @@
+# Stage Selection
+
+## When to Start from Stage 1 (LAP Computation)
+
+Always start from Stage 1 when `transition_graph` has not been computed yet or when the cell type list, vector field, or EM_steps need to change.
+
+Skip to later stages when `transition_graph` and `cells_indices` are already persisted to disk via `save_pickle`.
+
+## `marginal_method` Options
+
+Controls which cells are selected to represent each cell type attractor.
+
+| value | behavior |
+|---|---|
+| `combined` | integrates distance, degree, and potential — default; most robust |
+| `distance` | selects cells closest in embedding space to the attractor |
+| `degree` | selects cells by graph connectivity degree |
+| `potential` | selects cells by ddhodge potential value (requires `potential_column` to be meaningful) |
+
+Use `combined` unless you have reason to bias toward one selection criterion.
+
+## `basis_list` and `adj_key` Options
+
+- `basis_list=['umap', 'pca']` — default; computes LAPs in both spaces. UMAP is used for visualization, PCA for downstream TF analysis.
+- Set `umap_adj_key='X_umap_distances'` — this key is created by `dyn.tl.neighbors(adata, basis='umap', result_prefix='umap')`.
+- Set `pca_adj_key='cosine_transition_matrix'` — this key is created during RNA velocity estimation.
+
+If only UMAP-basis visualization is needed and TF analysis is not required, `basis_list=['umap']` is a valid shortcut.
+
+## `EM_steps` Parameter
+
+- `EM_steps=2` is the tutorial default; higher values improve cell selection but increase runtime.
+- For smoke paths or exploratory runs, `EM_steps=1` reduces computation significantly.
+
+## `lap_method` Options in `extract_transition_metrics`
+
+| value | behavior |
+|---|---|
+| `action` | returns only action functional values per transition |
+| `action_t` | returns both action and LAP integration time (in hours for labeling data) |
+
+Use `action_t` when reporting transition times, which is biologically meaningful for scNT-seq data because the RNA velocity has absolute time units (hours).
+
+## `plot_type` / `transition_type` Options in TF Analysis
+
+| value | behavior |
+|---|---|
+| `development` | differentiating paths from progenitor (e.g., HSC→Meg) |
+| `reprogramming` | reverse paths back to progenitor state (e.g., Meg→HSC) |
+| `transdifferentiation` | lateral transitions between mature cell types (e.g., Mon→Bas) |
+
+Call `analyze_transition_tfs` or `plot_transition_tf_analysis` once per transition type to generate the corresponding figure panel.
+
+## `transitions_config` Structure
+
+The `standard` key lists transitions handled with a single TF set per transition. The `special` key handles transitions with two alternative known TF sets:
+
+```python
+TRANSITIONS_CONFIG = {
+    "standard": [
+        "HSC->Meg", "HSC->Ery", "HSC->Bas", "HSC->Mon", "HSC->Neu",
+        "Meg->HSC", "Meg->Neu", "Ery->Mon", "Mon->Meg", "Mon->Ery",
+        "Mon->Bas", "Neu->Bas"
+    ],
+    "special": {
+        "Ery->Neu": {
+            "sets": [
+                ("TFs1", "TFs_rank1", "Ery->Neu1"),
+                ("TFs2", "TFs_rank2", "Ery->Neu2"),
+            ]
+        }
+    }
+}
+```
+
+Extend with additional `special` entries if other transitions have multiple competing TF literatures.
+
+## Three-Step vs. All-in-One Pattern
+
+Use `analyze_transition_tfs` (all-in-one) when:
+- you want a single function call that produces processed rankings, the matrix, and a plot for one `plot_type`
+- you do not need to inspect or modify intermediate results
+
+Use the three-step pattern (`process_all_transition_rankings → create_reprogramming_matrix → plot_transition_tf_analysis`) when:
+- you want to inspect `processed_rankings` before building the matrix
+- you want different `total_tf_count` or `known_tfs_dict` at each step
+- you want to plot multiple `transition_type` panels from the same `reprogramming_df`
+
+## ROC Analysis Scope
+
+`analyze_tf_roc_performance` uses all available transitions by default. Pass `transitions_to_include` to evaluate only a subset:
+
+```python
+development_transitions = ["HSC->Meg", "HSC->Ery", "HSC->Bas", "HSC->Mon", "HSC->Neu"]
+roc_results = dyn.pd.analyze_tf_roc_performance(
+    processed_rankings=processed_rankings,
+    transitions_to_include=development_transitions,
+)
+```
+
+The `roc_plot_params` dict is forwarded to `plot_roc_curve`. Supported keys: `figsize`, `fontsize`, `linewidth`, `roc_color`, `diagonal_color`, `title`, `legend_size`.

--- a/skills/dynamo-lineage-appearance-analysis/SKILL.md
+++ b/skills/dynamo-lineage-appearance-analysis/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: dynamo-lineage-appearance-analysis
+description: Compare lineage appearance timing and its regulators on a precomputed `dynamo` vector-field `AnnData` using topography, graph potentials, Jacobian, and vector-calculus outputs. Use when checking whether one lineage appears earlier than its peers, curating fixed points, analyzing regulator pairs on a downstream-ready vector field, or adapting `400_tutorial_hsc_dynamo_megakaryocytes_appearance.ipynb`.
+---
+
+# Dynamo Lineage Appearance Analysis
+
+## Goal
+
+Analyze whether one lineage appears earlier than related lineages in a precomputed `dynamo` dataset by combining fixed-point curation, transition-graph potentials, regulator-pair Jacobian analysis, and vector-calculus quantities such as speed, divergence, acceleration, and curvature.
+
+## Quick Workflow
+
+1. Inspect whether the `AnnData` already contains the vector-field and transition-graph outputs this workflow depends on.
+2. Choose the stage or stages you actually need: topography curation, appearance-order comparison, regulator-pair Jacobian, or vector-calculus follow-up.
+3. Use `build_graph(...)`, `div(...)`, and `potential(...)` on the relevant transition matrix instead of inferring lineage order from plots alone.
+4. Run `dyn.vf.jacobian(...)` on the regulator and effector genes of interest before interpreting lineage-specific interactions.
+5. Compute `speed`, `divergence`, `acceleration`, and `curvature` in the same basis you want to compare across cells.
+6. Validate output keys and return types before treating the analysis as complete.
+
+## Interface Summary
+
+- `dyn.sample_data.hematopoiesis(url='https://figshare.com/ndownloader/files/47439635', filename='hematopoiesis.h5ad')` loads the worked example used in this notebook family.
+- `dyn.vf.topography(adata, basis='umap', layer=None, X=None, dims=None, n=25, VecFld=None, show_progress=False, **kwargs)` maps fixed points onto the current vector field when they are missing or need remapping.
+- `dyn.pl.topography(..., basis='umap', fps_basis='umap', terms=['streamline', 'fixed_points'], quiver_source='raw', fate='both', n=25, ...)` is the main visualization entrypoint.
+- `build_graph(adj_mat)`, `div(g)`, and `potential(g, div_neg=None)` are the graph-operator primitives behind the notebook's appearance-order comparison.
+- `dyn.vf.jacobian(..., sampling=None, sample_ncells=1000, basis='pca', method='analytical')` computes cell-wise Jacobians from the reconstructed vector field.
+- `dyn.pl.jacobian(..., basis='umap', jkey='jacobian', j_basis='pca', layer='M_s', cmap='bwr')` visualizes selected Jacobian entries on an embedding.
+- `dyn.vf.speed(..., method='analytical')`, `dyn.vf.divergence(..., sampling=None, basis='pca', method='analytical')`, `dyn.vf.acceleration(..., basis='umap', method='analytical')`, and `dyn.vf.curvature(..., basis='pca', formula=2, method='analytical')` provide the main dynamical quantities used in the notebook.
+
+Read `references/source-grounding.md` before documenting narrower parameter behavior than the current source supports.
+
+## Stage Selection
+
+- Use the fixed-point stage when the task is to inspect or curate candidate attractors and saddles before downstream interpretation.
+- Use the graph-potential stage when the task is to compare appearance timing across related lineages with `cosine_transition_matrix` or `fp_transition_rate`.
+- Use the Jacobian stage when the task is to test a specific regulator pair, not when the user only wants a lineage-order figure.
+- Use the vector-calculus stage when the task is to compare `speed_pca`, `divergence_pca`, `acceleration_pca`, or `curvature_pca` across cell states.
+- Keep `basis='umap'` for notebook-style plotting and `basis='pca'` for Jacobian, divergence, and other quantities that rely on the PCA vector field.
+
+Read `references/stage-selection.md` before choosing non-default `method`, `formula`, `fate`, `terms`, or worked-example gene and lineage labels.
+
+## Input Contract
+
+- Expect a processed `AnnData` that already contains a reconstructed vector field, not raw counts alone.
+- Expect `adata.uns['VecFld_umap']` and usually `adata.uns['VecFld_pca']`.
+- Expect `adata.obsm['X_umap']` for plotting and `adata.uns['PCs']` for PCA-space back-projection.
+- Expect `adata.obsp['cosine_transition_matrix']` for the notebook's first potential comparison.
+- Expect `adata.obsp['fp_transition_rate']` if you want the Fokker-Planck-style potential branch.
+- Expect `adata.var.use_for_dynamics` and `adata.var.use_for_pca` when using Jacobian or PCA-basis vector calculus.
+- Treat notebook-specific `obs['cell_type']` labels such as `HSC`, `MEP-like`, `Meg`, `Ery`, and `Bas`, and genes such as `FLI1` and `KLF1`, as worked-example defaults rather than hard requirements.
+
+If the user only has raw counts or only wants upstream preprocessing or velocity fitting, route to a more appropriate skill instead of forcing this downstream analysis workflow.
+
+## Minimal Execution Patterns
+
+For the worked example load and appearance-order comparison:
+
+```python
+import dynamo as dyn
+from dynamo.tools.graph_operators import build_graph, div, potential
+
+adata = dyn.sample_data.hematopoiesis()
+
+g = build_graph(adata.obsp["cosine_transition_matrix"])
+cosine_div = div(g)
+adata.obs["cosine_potential"] = potential(g, -cosine_div)
+
+g_fp = build_graph(adata.obsp["fp_transition_rate"])
+fp_div = div(g_fp)
+adata.obs["potential_fp"] = potential(g_fp, fp_div)
+adata.obs["pseudotime_fp"] = -adata.obs["potential_fp"]
+```
+
+For fixed-point remapping or manual curation:
+
+```python
+dyn.vf.topography(adata, n=750, basis="umap")
+
+Xss = adata.uns["VecFld_umap"]["Xss"]
+ftype = adata.uns["VecFld_umap"]["ftype"]
+# choose the subset after inspecting the remapped fixed points for this dataset
+keep_idx = [...]
+
+adata.uns["VecFld_umap"]["Xss"] = Xss[keep_idx]
+adata.uns["VecFld_umap"]["ftype"] = ftype[keep_idx]
+
+dyn.pl.topography(
+    adata,
+    basis="umap",
+    fps_basis="umap",
+    color=["cell_type"],
+    streamline_alpha=0.9,
+    save_show_or_return="return",
+)
+```
+
+For regulator-pair Jacobian analysis and notebook-style plotting:
+
+```python
+genes = ["FLI1", "KLF1"]
+dyn.vf.jacobian(adata, regulators=genes, effectors=genes, basis="pca")
+
+dyn.pl.jacobian(
+    adata,
+    regulators=genes,
+    effectors=["FLI1"],
+    basis="umap",
+    save_show_or_return="return",
+)
+```
+
+For the vector-calculus follow-up:
+
+```python
+basis = "pca"
+dyn.vf.speed(adata, basis=basis)
+dyn.vf.divergence(adata, basis=basis)
+dyn.vf.acceleration(adata, basis=basis)
+dyn.vf.curvature(adata, basis=basis, formula=2)
+```
+
+For a bounded worked-example smoke check, use the command recorded in `assets/acceptance.json`.
+
+## Validation
+
+Before analysis, check these items:
+
+- `VecFld_umap` exists in `adata.uns`
+- `X_umap` exists in `adata.obsm`
+- `cosine_transition_matrix` exists in `adata.obsp`
+- `fp_transition_rate` exists in `adata.obsp` if the Fokker-Planck branch is needed
+
+After graph-potential comparison, check these items:
+
+- `cosine_potential` or your renamed cosine-potential column exists in `adata.obs`
+- `potential_fp` exists in `adata.obs` when you run the `fp_transition_rate` branch
+- `pseudotime_fp` exists and is the sign-flipped version used for notebook-style time interpretation
+
+After Jacobian analysis, check these items:
+
+- `jacobian_pca` exists in `adata.uns`
+- `adata.uns['jacobian_pca']` includes `jacobian`, `cell_idx`, `regulators`, and `effectors`
+- `dyn.pl.jacobian(..., save_show_or_return='return')` returns a `GridSpec`
+
+After vector-calculus analysis, check these items:
+
+- `speed_pca` exists in `adata.obs`
+- `divergence_pca` exists in `adata.obs`
+- `acceleration_pca` exists in `adata.obs`
+- `curvature_pca` exists in `adata.obs`
+- `acceleration` and `curvature` layers are created for the `pca` branch
+
+After topography plotting, check these items:
+
+- `adata.uns['VecFld_umap']['Xss']` and `adata.uns['VecFld_umap']['ftype']` still align after any manual curation
+- `dyn.pl.topography(..., save_show_or_return='return')` returns an `Axes`
+
+## Constraints
+
+- Do not treat the notebook's fixed-point indices as reusable defaults. They depend on the exact remapped topography, `n`, and current vector-field fit.
+- Do not use this skill as a raw-data preprocessing recipe. It assumes a downstream-ready `dynamo` object with vector-field outputs already present.
+- Do not recommend `curvature(..., formula=1)` as a normal branch in the current runtime. Source-grounded reviewer execution hit a runtime failure when that branch tried to write a missing matrix into `obsm`.
+- Do not recommend `dyn.pl.topography(..., quiver_source='reconstructed')` as a normal branch in the current runtime. Reviewer execution hit an `ImportError` in that branch.
+- Prefer the default topography `terms=['streamline', 'fixed_points']` unless the user explicitly needs additional overlays and you have checked the current source behavior.
+- Keep notebook cosmetics such as `dyn.pl.style(font_path='Arial')` out of the reusable workflow.
+
+## Resource Map
+
+- Read `references/stage-selection.md` when choosing between topography, appearance-order, Jacobian, and vector-calculus stages.
+- Read `references/worked-example.md` when the user specifically wants the HSC / MEP-like / Meg / Ery / Bas and FLI1 / KLF1 setup from the notebook.
+- Read `references/source-notebook-map.md` to trace notebook sections into this reusable skill.
+- Read `references/source-grounding.md` for inspected signatures, source-level branch behavior, empirical checks, and known runtime traps.
+- Read `references/compatibility.md` when notebook prose, parameter names, or current runtime behavior diverge.
+- Use `assets/acceptance.json` for the bounded worked-example smoke path used by local validation.

--- a/skills/dynamo-lineage-appearance-analysis/assets/acceptance.json
+++ b/skills/dynamo-lineage-appearance-analysis/assets/acceptance.json
@@ -1,0 +1,64 @@
+{
+  "version": 1,
+  "skill": "dynamo-lineage-appearance-analysis",
+  "sample_requests": [
+    "Analyze whether one lineage appears earlier than related lineages in a precomputed dynamo AnnData using topography, graph potentials, and Jacobian outputs",
+    "Adapt 400_tutorial_hsc_dynamo_megakaryocytes_appearance.ipynb into a reusable workflow for lineage appearance timing and regulator-pair analysis"
+  ],
+  "required_description_terms": [
+    "dynamo",
+    "lineage",
+    "appearance",
+    "anndata",
+    "topography",
+    "jacobian"
+  ],
+  "required_sections": [
+    "## Goal",
+    "## Quick Workflow",
+    "## Interface Summary",
+    "## Stage Selection",
+    "## Input Contract",
+    "## Minimal Execution Patterns",
+    "## Validation",
+    "## Resource Map"
+  ],
+  "required_body_terms": [
+    "cosine_transition_matrix",
+    "fp_transition_rate",
+    "topography",
+    "potential",
+    "jacobian_pca",
+    "speed_pca",
+    "curvature_pca",
+    "FLI1",
+    "KLF1"
+  ],
+  "required_paths": [
+    "references/stage-selection.md",
+    "references/worked-example.md",
+    "references/source-notebook-map.md",
+    "references/source-grounding.md",
+    "references/compatibility.md"
+  ],
+  "smoke_commands": [
+    {
+      "name": "worked-example-core-analysis",
+      "conda_env": "omictest",
+      "env": {
+        "PYTHONPATH": ".",
+        "MPLCONFIGDIR": "/tmp/mpl",
+        "NUMBA_CACHE_DIR": "/tmp/numba"
+      },
+      "command": "${PYTHON} - <<'PY'\nfrom __future__ import annotations\n\nimport json\nimport os\nimport warnings\n\nos.environ.setdefault(\"MPLCONFIGDIR\", \"/tmp/mpl\")\nos.environ.setdefault(\"NUMBA_CACHE_DIR\", \"/tmp/numba\")\n\nwarnings.filterwarnings(\"ignore\")\nwarnings.filterwarnings(\"ignore\", message=\"numpy.dtype size changed\")\n\nimport matplotlib\n\nmatplotlib.use(\"Agg\")\n\nimport dynamo as dyn\nfrom dynamo.tools.graph_operators import build_graph, div, potential\n\nadata = dyn.sample_data.hematopoiesis()\n\ncosine_graph = build_graph(adata.obsp[\"cosine_transition_matrix\"])\ncosine_div = div(cosine_graph)\nadata.obs[\"cosine_potential_smoke\"] = potential(cosine_graph, -cosine_div)\n\nfp_graph = build_graph(adata.obsp[\"fp_transition_rate\"])\nfp_div = div(fp_graph)\nadata.obs[\"potential_fp_smoke\"] = potential(fp_graph, fp_div)\nadata.obs[\"pseudotime_fp_smoke\"] = -adata.obs[\"potential_fp_smoke\"]\n\ngenes = [\"FLI1\", \"KLF1\"]\ndyn.vf.jacobian(adata, regulators=genes, effectors=genes, basis=\"pca\")\njacobian_plot = dyn.pl.jacobian(\n    adata,\n    regulators=genes,\n    effectors=[\"FLI1\"],\n    basis=\"umap\",\n    save_show_or_return=\"return\",\n)\n\nbasis = \"pca\"\ndyn.vf.speed(adata, basis=basis)\ndyn.vf.divergence(adata, basis=basis)\ndyn.vf.acceleration(adata, basis=basis)\ndyn.vf.curvature(adata, basis=basis, formula=2)\n\ntopography_plot = dyn.pl.topography(\n    adata,\n    basis=\"umap\",\n    fps_basis=\"umap\",\n    color=[\"cell_type\"],\n    streamline_alpha=0.9,\n    save_show_or_return=\"return\",\n)\n\nsummary = {\n    \"cosine_potential_smoke\": \"cosine_potential_smoke\" in adata.obs,\n    \"potential_fp_smoke\": \"potential_fp_smoke\" in adata.obs,\n    \"pseudotime_fp_smoke\": \"pseudotime_fp_smoke\" in adata.obs,\n    \"jacobian_pca\": \"jacobian_pca\" in adata.uns,\n    \"speed_pca\": \"speed_pca\" in adata.obs,\n    \"divergence_pca\": \"divergence_pca\" in adata.obs,\n    \"acceleration_pca\": \"acceleration_pca\" in adata.obs,\n    \"curvature_pca\": \"curvature_pca\" in adata.obs,\n    \"VecFld_umap\": \"VecFld_umap\" in adata.uns,\n    \"jacobian_plot_return\": type(jacobian_plot).__name__,\n    \"topography_return\": type(topography_plot).__name__,\n}\n\nprint(json.dumps(summary, sort_keys=True))\nPY",
+      "timeout_seconds": 300,
+      "expect_stdout_contains": [
+        "\"jacobian_plot_return\": \"GridSpec\"",
+        "\"topography_return\": \"Axes\"",
+        "\"speed_pca\": true",
+        "\"curvature_pca\": true",
+        "\"VecFld_umap\": true"
+      ]
+    }
+  ]
+}

--- a/skills/dynamo-lineage-appearance-analysis/references/compatibility.md
+++ b/skills/dynamo-lineage-appearance-analysis/references/compatibility.md
@@ -1,0 +1,70 @@
+# Compatibility
+
+Use this note when notebook behavior and current runtime behavior diverge.
+
+## Fixed-Point Indices Are Not Stable Defaults
+
+The notebook's manual fixed-point selection:
+
+```python
+good_fixed_points = [2, 8, 1, 195, 4, 5]
+```
+
+is only meaningful after remapping the same dataset with the same `basis`, `n`, and vector-field state.
+
+Do not copy those indices into a different dataset or a differently remapped vector field.
+
+## `quiver_source='reconstructed'` Is Not Safe In The Current Runtime
+
+Reviewer execution on the current source hit:
+
+```text
+ImportError: cannot import name 'vector_field_function' from 'dynamo.tools.utils'
+```
+
+when `dyn.pl.topography(..., quiver_source='reconstructed')` was used.
+
+Practical rule:
+
+- use the default `quiver_source='raw'`
+- if you need reconstructed quivers, patch or verify the source first
+
+## `curvature(formula=1)` Is Not Safe In The Current Runtime
+
+Reviewer execution on the current source hit:
+
+```text
+AttributeError: 'NoneType' object has no attribute 'shape'
+```
+
+because `formula=1` produced no curvature matrix while the function still attempted to write it into `adata.obsm`.
+
+Practical rule:
+
+- prefer `formula=2`
+- only use `formula=1` after confirming the runtime has been fixed
+
+## `terms` Naming Drift In `dyn.pl.topography`
+
+The docstring mentions `separatrix`, but the implementation checks for `separatrices`.
+
+Practical rule:
+
+- rely on the default `terms=['streamline', 'fixed_points']`
+- verify any non-default `terms` branch directly against current source
+
+## Notebook Cosmetics Are Not Part Of The Skill Contract
+
+The notebook includes presentation-only setup such as:
+
+- `dyn.configuration.set_figure_params(...)`
+- `dyn.pl.style(font_path='Arial')`
+- bespoke seaborn and matplotlib layout code
+
+These should stay out of the core reusable workflow unless the user explicitly asks for figure styling parity.
+
+## Upstream Dependency Boundary
+
+This skill assumes the data already has vector-field outputs and transition graphs.
+
+If a user only has raw data, they still need upstream preprocessing, dynamics, velocity, and vector-field reconstruction before this notebook-derived analysis makes sense.

--- a/skills/dynamo-lineage-appearance-analysis/references/source-grounding.md
+++ b/skills/dynamo-lineage-appearance-analysis/references/source-grounding.md
@@ -1,0 +1,219 @@
+# Source Grounding
+
+This skill was generated from notebook inspection, live interface inspection, source-code reads, and bounded empirical execution on real `dynamo` sample data.
+
+## Inspection Notes
+
+Live inspection used the repository's current source and a local Python runtime compatible with this repository for callable inspection and smoke execution.
+
+## Primary Source Files
+
+Notebook inspected:
+
+- `docs/tutorials/notebooks/400_tutorial_hsc_dynamo_megakaryocytes_appearance.ipynb`
+
+Code inspected:
+
+- `dynamo/vectorfield/vector_calculus.py`
+- `dynamo/plot/topography.py`
+- `dynamo/tools/graph_operators.py`
+- `dynamo/sample_data.py`
+
+## Inspected Interfaces
+
+### `dyn.sample_data.hematopoiesis`
+
+Observed signature:
+
+```python
+(url='https://figshare.com/ndownloader/files/47439635', filename='hematopoiesis.h5ad')
+```
+
+Observed runtime note:
+
+- the loader uses a processed worked example and may download `hematopoiesis.h5ad` into `./data/`
+
+### `dyn.vf.topography`
+
+Observed signature:
+
+```python
+(adata, basis='umap', layer=None, X=None, dims=None, n=25, VecFld=None, show_progress=False, **kwargs)
+```
+
+Observed behavior:
+
+- updates `adata.uns['VecFld_' + basis]`
+- is the remapping step when fixed points need recalculation
+
+### `dyn.pl.topography`
+
+Observed signature includes:
+
+```python
+(..., basis='umap', fps_basis='umap', terms=['streamline', 'fixed_points'], quiver_source='raw', fate='both', n=25, ...)
+```
+
+Observed branch details from current source:
+
+- `quiver_source`: `raw`, `reconstructed`
+- `fate`: `history`, `future`, `both`
+- `terms` is normalized into a list and `trajectory` is appended automatically when `init_cells` or `init_states` is provided
+- integration direction maps to `backward`, `forward`, or `both` depending on `fate`
+
+Observed runtime trap:
+
+- `quiver_source='reconstructed'` currently hits `ImportError: cannot import name 'vector_field_function' from 'dynamo.tools.utils'`
+
+Observed source trap:
+
+- the docstring advertises `separatrix`, but the implementation checks for `separatrices`
+
+### `build_graph`, `div`, `potential`
+
+Observed signatures:
+
+```python
+build_graph(adj_mat)
+div(g)
+potential(g, div_neg=None)
+```
+
+Observed source details:
+
+- `build_graph(...)` uses `Graph.Weighted_Adjacency(adj_mat)`
+- `potential(...)` defaults to `-div(g)` when `div_neg` is omitted
+- the notebook intentionally passes different signs for the cosine and Fokker-Planck branches
+
+### `dyn.vf.jacobian`
+
+Observed signature includes:
+
+```python
+(..., sampling=None, sample_ncells=1000, basis='pca', method='analytical', store_in_adata=True, **kwargs)
+```
+
+Observed branch details:
+
+- `sampling`: `None`, `random`, `velocity`, `trn`
+- `method`: `analytical`, `numerical`
+
+Observed source details:
+
+- if `basis='umap'`, current code forces `cell_idx = np.arange(adata.n_obs)`
+- when regulators or effectors are strings matching a boolean `adata.var` column, they expand to the flagged genes
+- for `basis='pca'`, the selected Jacobian is inverse-transformed through `adata.uns['PCs']`
+
+Observed output structure:
+
+- `adata.uns['jacobian_pca']` contains `jacobian`, `cell_idx`, `regulators`, `effectors`, and `jacobian_gene`
+
+### `dyn.pl.jacobian`
+
+Observed signature includes:
+
+```python
+(..., basis='umap', jkey='jacobian', j_basis='pca', layer='M_s', cmap='bwr', sort='abs', ...)
+```
+
+Observed runtime detail:
+
+- `save_show_or_return='return'` returned a `GridSpec` on the worked example
+
+### `dyn.vf.speed`
+
+Observed signature:
+
+```python
+(adata, basis='umap', vector_field_class=None, method='analytical')
+```
+
+Observed branch detail:
+
+- `method='analytical'` evaluates the vector field directly
+- non-analytical mode falls back to stored velocity vectors such as `adata.obsm['velocity_' + basis]`
+
+### `dyn.vf.divergence`
+
+Observed signature includes:
+
+```python
+(..., sampling=None, sample_ncells=1000, basis='pca', method='analytical', store_in_adata=True, **kwargs)
+```
+
+Observed branch details:
+
+- `sampling`: `None`, `random`, `velocity`, `trn`
+- `method`: `analytical`, `numeric`
+
+Observed source detail:
+
+- if `jacobian_pca` is already present, current code reuses those entries before computing any missing divergence values
+
+### `dyn.vf.acceleration`
+
+Observed signature:
+
+```python
+(adata, basis='umap', vector_field_class=None, Qkey='PCs', method='analytical', **kwargs)
+```
+
+Observed branch details:
+
+- `method`: `analytical`, `numerical`
+- for `basis='pca'`, the function creates both `obs['acceleration_pca']`, `obsm['acceleration_pca']`, and a high-dimensional `layers['acceleration']`
+
+### `dyn.vf.curvature`
+
+Observed signature:
+
+```python
+(adata, basis='pca', vector_field_class=None, formula=2, Qkey='PCs', method='analytical', **kwargs)
+```
+
+Observed branch details:
+
+- `formula`: `1`, `2`
+- `method`: `analytical`, `numerical`
+
+Observed runtime trap:
+
+- `formula=1` failed in reviewer execution because `curv_mat` was `None` while the function still wrote it into `adata.obsm[curvature_key]`
+
+## Empirical Checks Run
+
+### Worked-Example Data Contract
+
+Observed on `dyn.sample_data.hematopoiesis()`:
+
+- shape `1947 x 1956`
+- `obsp` includes `cosine_transition_matrix` and `fp_transition_rate`
+- `uns` includes `VecFld_pca`, `VecFld_umap`, and `PCs`
+- `obsm` includes `X_umap`, `velocity_umap`, `acceleration_pca`, and `curvature_pca`
+
+### Core Analysis Smoke
+
+A bounded local smoke used the shipped hematopoiesis example and successfully:
+
+1. built cosine and Fokker-Planck graphs
+2. computed `cosine_potential`, `potential_fp`, and `pseudotime_fp`
+3. ran `dyn.vf.jacobian(...)` on `FLI1` and `KLF1`
+4. plotted `dyn.pl.jacobian(..., save_show_or_return='return')`
+5. ran `speed`, `divergence`, `acceleration`, and `curvature(formula=2)` in `basis='pca'`
+6. plotted `dyn.pl.topography(..., save_show_or_return='return')`
+
+Observed outputs:
+
+- `jacobian_plot_return` was `GridSpec`
+- `topography_return` was `Axes`
+- `speed_pca`, `divergence_pca`, `acceleration_pca`, and `curvature_pca` existed
+- `VecFld_umap` remained present
+
+### Branch Diagnostics
+
+Additional local diagnostics also checked two branch-heavy runtime paths:
+
+- `dyn.vf.curvature(..., formula=1)` failed in the current runtime
+- `dyn.pl.topography(..., quiver_source='reconstructed')` failed in the current runtime
+
+Those branches are documented as compatibility risks instead of recommended defaults.

--- a/skills/dynamo-lineage-appearance-analysis/references/source-notebook-map.md
+++ b/skills/dynamo-lineage-appearance-analysis/references/source-notebook-map.md
@@ -1,0 +1,125 @@
+# Source Notebook Map
+
+Notebook inspected:
+
+- `docs/tutorials/notebooks/400_tutorial_hsc_dynamo_megakaryocytes_appearance.ipynb`
+
+## Notebook To Skill Mapping
+
+### Notebook Intro And Setup
+
+Notebook cells:
+
+- data load with `dyn.sample_data.hematopoiesis()`
+- environment and plotting setup
+
+Mapped skill resources:
+
+- `SKILL.md` Goal
+- `SKILL.md` Input Contract
+- `references/worked-example.md`
+
+Reusable decision:
+
+- keep the data-contract details
+- drop notebook-only `%autoreload` and font styling
+
+### Topography And Fixed-Point Curation
+
+Notebook cells:
+
+- `dyn.vf.topography(...)`
+- `dyn.pl.topography(...)`
+- manual `Xss` and `ftype` subsetting
+
+Mapped skill resources:
+
+- `SKILL.md` Stage Selection
+- `SKILL.md` Minimal Execution Patterns
+- `references/stage-selection.md`
+- `references/compatibility.md`
+
+Reusable decision:
+
+- preserve the pattern of remapping then manually curating fixed points
+- demote the concrete fixed-point indices to a worked example
+
+### Vector-Field Pseudotime / Potential Comparison
+
+Notebook cells:
+
+- `build_graph(...)`
+- `div(...)`
+- `potential(...)`
+- `potential_fp` and `pseudotime_fp`
+- ECDF visualizations
+
+Mapped skill resources:
+
+- `SKILL.md` Quick Workflow
+- `SKILL.md` Minimal Execution Patterns
+- `references/stage-selection.md`
+- `references/source-grounding.md`
+
+Reusable decision:
+
+- preserve the graph-operator spine
+- drop the notebook-specific seaborn styling
+
+### Molecular Mechanism / Jacobian
+
+Notebook cells:
+
+- `Meg_genes = ['FLI1', 'KLF1']`
+- `dyn.vf.jacobian(...)`
+- `dyn.pl.jacobian(...)`
+- expression plots for `FLI1` and `KLF1`
+
+Mapped skill resources:
+
+- `SKILL.md` Minimal Execution Patterns
+- `SKILL.md` Validation
+- `references/worked-example.md`
+- `references/source-grounding.md`
+
+Reusable decision:
+
+- keep the regulator-pair workflow
+- treat `FLI1` and `KLF1` as worked-example defaults
+
+### Speed / Divergence / Acceleration / Curvature
+
+Notebook cells:
+
+- `dyn.vf.speed(...)`
+- `dyn.vf.divergence(...)`
+- `dyn.vf.acceleration(...)`
+- `dyn.vf.curvature(...)`
+- notebook-style visualization panel
+
+Mapped skill resources:
+
+- `SKILL.md` Minimal Execution Patterns
+- `references/stage-selection.md`
+- `references/source-grounding.md`
+- `references/compatibility.md`
+
+Reusable decision:
+
+- keep the quantity-computation spine
+- drop the exact notebook subplot layout
+
+### Narrative Conclusion
+
+Notebook cells:
+
+- final biological interpretation and schematic image
+
+Mapped skill resources:
+
+- not promoted into the main workflow
+
+Reusable decision:
+
+- retain the analysis steps that support the conclusion
+- do not encode the conclusion itself as if it were universally true for every dataset

--- a/skills/dynamo-lineage-appearance-analysis/references/stage-selection.md
+++ b/skills/dynamo-lineage-appearance-analysis/references/stage-selection.md
@@ -1,0 +1,81 @@
+# Stage Selection
+
+Use this reference to decide which subset of the notebook to reuse.
+
+## 1. Fixed-Point And Topography Stage
+
+Use this stage when the user needs to inspect candidate attractors, saddles, or manual fixed-point curation.
+
+Default path:
+
+- trust existing `adata.uns['VecFld_umap']` if it already contains plausible `Xss` and `ftype`
+- run `dyn.vf.topography(adata, basis='umap', n=...)` only when fixed points need remapping
+- plot with `dyn.pl.topography(..., basis='umap', fps_basis='umap')`
+
+Branch notes:
+
+- `n` controls how many samples are used for fixed-point search; manual fixed-point indices are not portable across different `n`
+- `terms` defaults to `['streamline', 'fixed_points']`
+- `fate='both'` maps to bidirectional integration when trajectories are drawn
+- `quiver_source='raw'` is the safe default in the current runtime
+
+Use this stage alone if the task is mostly landscape inspection.
+
+## 2. Appearance-Order Comparison Stage
+
+Use this stage when the user needs a defensible claim that one lineage appears earlier than another, not just a UMAP screenshot.
+
+Core operators:
+
+- `build_graph(adata.obsp['cosine_transition_matrix'])`
+- `div(g)`
+- `potential(g, -divergence)` for the cosine branch used in the notebook
+- `build_graph(adata.obsp['fp_transition_rate'])`
+- `potential(g_fp, fp_divergence)` for the notebook's Fokker-Planck branch
+
+Interpretation notes:
+
+- `potential(...)` returns a nonnegative shifted potential
+- the notebook interprets smaller potential as earlier intrinsic time
+- the notebook flips the sign for `pseudotime_fp = -potential_fp`
+
+Use this stage whenever lineage-order claims are central to the answer.
+
+## 3. Regulator-Pair Jacobian Stage
+
+Use this stage when the user wants to test or visualize a specific regulatory interaction.
+
+Default path:
+
+- choose regulators and effectors explicitly
+- run `dyn.vf.jacobian(..., basis='pca', method='analytical')`
+- plot with `dyn.pl.jacobian(..., basis='umap', j_basis='pca')`
+
+Branch notes:
+
+- `sampling` can be `None`, `random`, `velocity`, or `trn`
+- `method` can be `analytical` or `numerical`
+- if `basis='umap'`, current source forces all cells instead of sampled subsets
+- if `regulators` or `effectors` are strings matching a boolean column in `adata.var`, current code expands them to gene lists
+
+Use this stage when the user asks about FLI1/KLF1-like gene-pair behavior or other lineage-defining regulators.
+
+## 4. Vector-Calculus Stage
+
+Use this stage when the user wants dynamic quantities rather than only a Jacobian map.
+
+Default path:
+
+- `dyn.vf.speed(adata, basis='pca', method='analytical')`
+- `dyn.vf.divergence(adata, basis='pca', method='analytical')`
+- `dyn.vf.acceleration(adata, basis='pca', method='analytical')`
+- `dyn.vf.curvature(adata, basis='pca', formula=2, method='analytical')`
+
+Branch notes:
+
+- `speed(..., method='numeric')` falls back to stored velocity vectors instead of analytical field evaluation
+- `divergence(...)` can reuse precomputed `jacobian_pca` entries when present
+- `curvature(..., formula=2)` returns both the norm and matrix in the current design
+- `curvature(..., formula=1)` is source-documented but failed in reviewer execution in this runtime
+
+Use this stage when the user wants to compare how rapidly or sharply different lineages move through the field.

--- a/skills/dynamo-lineage-appearance-analysis/references/worked-example.md
+++ b/skills/dynamo-lineage-appearance-analysis/references/worked-example.md
@@ -1,0 +1,45 @@
+# Worked Example
+
+This notebook family uses the processed hematopoiesis example bundled in `dyn.sample_data.hematopoiesis()`.
+
+## Observed Worked-Example Inputs
+
+Observed on the current sample:
+
+- shape: `1947 x 1956`
+- `obs['cell_type']` includes labels such as `HSC`, `MEP-like`, `Meg`, `Ery`, and `Bas`
+- `obsm` already includes `X_pca`, `X_umap`, `velocity_pca`, `velocity_umap`, `acceleration_pca`, and `curvature_pca`
+- `obsp` already includes `cosine_transition_matrix` and `fp_transition_rate`
+- `uns` already includes `VecFld_pca`, `VecFld_umap`, `PCs`, and `dynamics`
+
+## Notebook-Specific Defaults
+
+The notebook focuses on:
+
+- lineage labels: `HSC`, `MEP-like`, `Meg`, `Ery`, `Bas`
+- regulator pair: `FLI1`, `KLF1`
+- fixed-point curation after `dyn.vf.topography(..., n=750)`
+- notebook-style plots on `basis='umap'`
+- Jacobian and vector-calculus quantities in `basis='pca'`
+
+## Reuse Rule
+
+Treat these as defaults only when the user is explicitly adapting the megakaryocyte-appearance notebook or analyzing a closely related hematopoiesis dataset.
+
+For a generalized lineage-appearance task:
+
+- replace `cell_type` with the user's grouping column
+- replace `FLI1` and `KLF1` with the regulator and effector genes of interest
+- keep the graph-operator and vector-calculus workflow intact
+
+## Worked-Example Cell Filter
+
+The notebook narrows some plots to:
+
+- `HSC`
+- `MEP-like`
+- `Meg`
+- `Ery`
+- `Bas`
+
+That filtering is useful for the narrative, but it is not part of the generic skill contract.

--- a/skills/dynamo-one-shot-total-rna-velocity/SKILL.md
+++ b/skills/dynamo-one-shot-total-rna-velocity/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: dynamo-one-shot-total-rna-velocity
+description: Run or adapt a one-shot total RNA velocity workflow in `dynamo` for metabolic-labeling or scNT-seq `AnnData`, including monocle preprocessing with an optional curated gene list, grouped moments by labeling time, Model-2 `dynamics`, `calculate_velocity_alpha_minus_gamma_s`, low-dimensional projection with `cell_velocities`, and optional streamline or phase-portrait plotting. Use when converting tutorials such as `301_tutorial_hsc_velocity.ipynb`, or when choosing between `one_shot_method` branches like `sci_fate` and `combined` and projection `method` branches like `cosine` and `pearson`.
+---
+
+# Dynamo One-Shot Total RNA Velocity
+
+## Goal
+
+Run the stable execution spine behind the hematopoiesis scNT-seq tutorial: preprocess a one-shot labeling dataset, smooth by labeling time, force the Model-2 no-splicing branch for kinetics, compute total RNA velocity with `alpha - gamma * s`, then project that custom velocity to a low-dimensional embedding without treating the tutorial dataset as the workflow identity.
+
+## Quick Workflow
+
+1. Inspect the input `AnnData` for `new`, `total`, and `time`, plus any reusable helpers such as `uns["genes_to_use"]` and `obsm["X_umap"]`.
+2. Preprocess with the monocle path. If a curated gene list exists, preserve it explicitly and use `Preprocessor(force_gene_list=...)` plus `config_monocle_recipe(..., n_top_genes=len(gene_list))`.
+3. Materialize grouped moments with `dyn.tl.moments(..., group='time')` so the one-shot fit sees time-specific neighborhoods and creates `M_n`, `M_t`, and `M_s`.
+4. Force the no-splicing Model-2 branch by setting `adata.uns["pp"]["has_splicing"] = False`, then run `dyn.tl.dynamics(..., group='time', one_shot_method='sci_fate', model='deterministic')` unless the user explicitly wants another branch.
+5. Convert the fitted kinetic parameters into total RNA velocity with `dyn.tl.calculate_velocity_alpha_minus_gamma_s(...)`.
+6. Project the custom total RNA velocity with `dyn.tl.cell_velocities(..., X=adata.layers["M_t"], V=adata.layers["velocity_alpha_minus_gamma_s"], method='cosine')`.
+7. Treat `streamline_plot` and `phase_portraits` as optional visualization steps after `velocity_umap` already exists.
+
+## Interface Summary
+
+- `Preprocessor.config_monocle_recipe(adata, n_top_genes=2000)` configures the notebook-style monocle preprocessing path.
+- `Preprocessor.preprocess_adata_monocle(adata, tkey=None, experiment_type=None)` is the exact notebook entrypoint; `Preprocessor.preprocess_adata(..., recipe='monocle', ...)` is the higher-level wrapper.
+- `dyn.tl.moments(..., group=None, use_gaussian_kernel=False, use_mnn=False, layers='all')` creates smoothed first and second moments and stores `obsp["moments_con"]`.
+- `dyn.tl.dynamics(..., group=None, model='auto', est_method='auto', one_shot_method='combined', ...)` estimates one-shot kinetic parameters and writes velocity-like layers such as `velocity_N` and `velocity_T`.
+- `dyn.tl.calculate_velocity_alpha_minus_gamma_s(adata, gene_subset_key='use_for_pca', velocity_layer_name='velocity_alpha_minus_gamma_s')` converts fitted rates plus `M_n` and `M_s` into the total RNA velocity layer used in the notebook.
+- `dyn.tl.cell_velocities(..., X=None, V=None, basis='umap', method='pearson', adj_key='distances', enforce=False)` projects the custom velocity to low-dimensional space and stores a kernel-specific transition matrix.
+- `dyn.pl.streamline_plot(..., basis='umap', method='gaussian')` and `dyn.pl.phase_portraits(...)` are optional presentation entrypoints after the analytical path is complete.
+
+Read `references/source-grounding.md` before documenting narrower parameter behavior than the live source currently supports.
+
+## Branch Selection
+
+- Use the curated-gene-list branch when `uns["genes_to_use"]` or a user-supplied marker/HVG list exists. Preserve that list explicitly before subsetting or concatenating because `anndata.concat(...)` can drop it.
+- Use `recipe='monocle'` for this workflow family. Other `recipe` branches are real source-level options, but the total-RNA one-shot path here was empirically checked only on the monocle branch.
+- Use `group='time'` on `moments(...)` and `dynamics(...)` unless the user explicitly wants to smooth and fit without time-specific neighborhoods.
+- Use `one_shot_method='sci_fate'` for notebook parity and `one_shot_method='combined'` when the user explicitly wants the steady-state-plus-absolute-gamma branch. Both were empirically checked.
+- Use `model='deterministic'` by default for this total-RNA workflow. If the user wants a splicing-aware or stochastic branch, stop and switch to a different workflow instead of silently mixing models.
+- Use `cell_velocities(..., method='cosine')` for notebook-style total-RNA projection. Use `method='pearson'` when the user wants the alternate kernel with a different transition-matrix key. Treat `kmc`, `fp`, and `transform` as advanced branches with extra assumptions.
+- Use `streamline_plot(..., method='gaussian')` for default streamline rendering. Switch to `method='SparseVFC'` only after a vector field has been reconstructed and the user explicitly wants that rendering path.
+
+Read `references/branch-selection.md` before choosing non-default `recipe`, `one_shot_method`, `model`, `method`, or plotting branches.
+
+## Input Contract
+
+- Expect a metabolic-labeling `AnnData` with usable `new` and `total` layers and a labeling-time column.
+- Expect the time column to be accessible as `adata.obs["time"]` before calling `calculate_velocity_alpha_minus_gamma_s(...)`, or rename / copy the user's time key to `time`.
+- Treat `spliced` and `unspliced` as optional inputs for the raw object, not as the target model branch. The notebook-compatible total-RNA path forces `has_splicing=False` before `dynamics(...)`.
+- Expect `M_n`, `M_t`, and `M_s` to be created by `moments(...)` before calling `calculate_velocity_alpha_minus_gamma_s(...)`.
+- Expect a valid embedding such as `X_umap` plus a matching adjacency matrix under `obsp["distances"]` before calling `cell_velocities(...)`.
+- Treat tutorial-specific fields such as `genes_to_use`, `cell_type`, and the hematopoiesis sample layout as worked examples, not universal defaults.
+
+## Minimal Execution Patterns
+
+For the notebook-compatible one-shot total RNA workflow:
+
+```python
+import dynamo as dyn
+
+adata = dyn.sample_data.hematopoiesis_raw()
+adata.obs_names_make_unique()
+
+selected_genes = list(adata.uns["genes_to_use"])
+
+pre = dyn.pp.Preprocessor(force_gene_list=selected_genes)
+pre.config_monocle_recipe(adata, n_top_genes=len(selected_genes))
+pre.preprocess_adata_monocle(adata, tkey="time", experiment_type="one-shot")
+
+dyn.tl.reduceDimension(adata)
+dyn.tl.moments(adata, group="time")
+
+adata.uns["pp"]["has_splicing"] = False
+dyn.tl.dynamics(
+    adata,
+    group="time",
+    one_shot_method="sci_fate",
+    model="deterministic",
+    cores=1,
+)
+
+dyn.tl.calculate_velocity_alpha_minus_gamma_s(adata)
+dyn.tl.cell_velocities(
+    adata,
+    enforce=True,
+    X=adata.layers["M_t"],
+    V=adata.layers["velocity_alpha_minus_gamma_s"],
+    method="cosine",
+)
+```
+
+For a generic one-shot labeling dataset without a baked-in gene list:
+
+```python
+pre = dyn.pp.Preprocessor()
+pre.preprocess_adata(adata, recipe="monocle", tkey="time", experiment_type="one-shot")
+```
+
+For a non-default `combined` one-shot branch:
+
+```python
+dyn.tl.dynamics(
+    adata,
+    group="time",
+    one_shot_method="combined",
+    model="deterministic",
+    cores=1,
+)
+```
+
+For a non-default `pearson` projection branch:
+
+```python
+dyn.tl.cell_velocities(
+    adata,
+    enforce=True,
+    X=adata.layers["M_t"],
+    V=adata.layers["velocity_alpha_minus_gamma_s"],
+    method="pearson",
+)
+```
+
+## Validation
+
+After preprocessing, check these items:
+
+- `adata.uns["pp"]["experiment_type"] == "one-shot"`
+- `adata.var["use_for_pca"]` exists
+- `adata.obsm["X_pca"]` exists
+
+After `moments(..., group='time')`, check these items:
+
+- `adata.obsp["moments_con"]` exists
+- `adata.layers["M_n"]`, `adata.layers["M_t"]`, and `adata.layers["M_s"]` exist
+
+Before `dynamics(...)`, check these items:
+
+- `adata.obs["time"]` exists
+- `adata.uns["pp"]["has_splicing"] is False` for the Model-2 branch
+
+After `dynamics(...)`, check these items:
+
+- `adata.uns["dynamics"]["model"] == "deterministic"` for the default branch
+- `adata.layers["velocity_T"]` exists
+- `adata.var["use_for_dynamics"]` exists
+
+After `calculate_velocity_alpha_minus_gamma_s(...)`, check these items:
+
+- `adata.layers["velocity_alpha_minus_gamma_s"]` exists
+- the function reports each unique time point it processed
+
+After `cell_velocities(...)`, check these items:
+
+- `adata.obsm["velocity_umap"]` exists for the default UMAP branch
+- `adata.obsp["cosine_transition_matrix"]` exists for `method='cosine'`
+- `adata.obsp["pearson_transition_matrix"]` exists for `method='pearson'`
+
+## Constraints
+
+- Do not treat `velocity_T` from `dynamics(...)` as the notebook endpoint. The tutorial's total-RNA visualization path depends on the extra `calculate_velocity_alpha_minus_gamma_s(...)` plus `cell_velocities(...)` steps.
+- Do not forget to rename or copy the time column to `adata.obs["time"]` before `calculate_velocity_alpha_minus_gamma_s(...)`; current source hard-codes that key.
+- Do not assume `uns["genes_to_use"]` survives `AnnData` concatenation or subsetting workflows. Preserve it explicitly when reconstructing subsets.
+- Do not keep `has_splicing=True` if the goal is Model-2 total RNA velocity. Preprocessing auto-detects splicing and labeling together on the hematopoiesis raw object.
+- Do not interpret `one_shot_method` from `adata.uns["dynamics"]`; current runtime does not store it there.
+- Do not make small per-time groups the default. Reviewer runs with fewer than `50` cells per time group emitted NaN-velocity warnings and filtered genes before projection.
+
+## Resource Map
+
+- Read `references/branch-selection.md` for decision rules across `recipe`, grouped smoothing, `one_shot_method`, and projection `method` branches.
+- Read `references/visualization-and-phase-portraits.md` when the user explicitly wants notebook-style streamlines or total-RNA phase-portrait adaptation.
+- Read `references/source-grounding.md` for inspected signatures, source-level branch evidence, and empirical execution notes.
+- Read `references/source-notebook-map.md` to see how `docs/tutorials/notebooks/301_tutorial_hsc_velocity.ipynb` was converted into this reusable skill.
+- Read `references/compatibility.md` when notebook wording and current source behavior diverge.

--- a/skills/dynamo-one-shot-total-rna-velocity/assets/acceptance.json
+++ b/skills/dynamo-one-shot-total-rna-velocity/assets/acceptance.json
@@ -1,0 +1,72 @@
+{
+  "version": 1,
+  "skill": "dynamo-one-shot-total-rna-velocity",
+  "sample_requests": [
+    "Convert the hematopoiesis one-shot labeling tutorial into a reusable dynamo total RNA velocity workflow",
+    "Run one-shot total RNA velocity in dynamo on a metabolic-labeling AnnData and choose between sci_fate and combined branches"
+  ],
+  "required_description_terms": [
+    "dynamo",
+    "one-shot",
+    "total RNA",
+    "velocity",
+    "AnnData",
+    "tutorial"
+  ],
+  "required_sections": [
+    "## Goal",
+    "## Quick Workflow",
+    "## Interface Summary",
+    "## Branch Selection",
+    "## Minimal Execution Patterns",
+    "## Validation",
+    "## Resource Map"
+  ],
+  "required_body_terms": [
+    "one_shot_method",
+    "calculate_velocity_alpha_minus_gamma_s",
+    "genes_to_use",
+    "has_splicing",
+    "M_t",
+    "velocity_alpha_minus_gamma_s",
+    "cosine_transition_matrix",
+    "pearson_transition_matrix"
+  ],
+  "required_paths": [
+    "references/branch-selection.md",
+    "references/visualization-and-phase-portraits.md",
+    "references/source-notebook-map.md",
+    "references/source-grounding.md",
+    "references/compatibility.md"
+  ],
+  "smoke_commands": [
+    {
+      "name": "sci-fate-cosine-total-rna",
+      "conda_env": "omictest",
+      "env": {
+        "PYTHONPATH": "/Users/fernandozeng/Desktop/analysis/dynamo-release",
+        "MPLCONFIGDIR": "/tmp/mpl",
+        "NUMBA_CACHE_DIR": "/tmp/numba"
+      },
+      "command": "${PYTHON} -c \"import anndata as ad, dynamo as dyn; raw=dyn.sample_data.hematopoiesis_raw(); selected=list(raw.uns['genes_to_use']); pairs=[('3','HSC',20),('5','HSC',20),('3','MEP-like',20),('5','MEP-like',20)]; parts=[raw[(raw.obs['time'].astype(str)==t) & (raw.obs['cell_type']==c)][:n].copy() for t,c,n in pairs]; adata=ad.concat(parts, merge='same', label='subset_group', keys=[f'{t}_{c}' for t,c,_ in pairs], index_unique='-'); adata.obs_names_make_unique(); adata.uns['genes_to_use']=selected; pre=dyn.pp.Preprocessor(force_gene_list=selected); pre.config_monocle_recipe(adata, n_top_genes=len(selected)); pre.preprocess_adata_monocle(adata, tkey='time', experiment_type='one-shot'); dyn.tl.reduceDimension(adata); dyn.tl.moments(adata, group='time'); adata.uns['pp']['has_splicing']=False; dyn.tl.dynamics(adata, group='time', one_shot_method='sci_fate', model='deterministic', cores=1); dyn.tl.calculate_velocity_alpha_minus_gamma_s(adata); dyn.tl.cell_velocities(adata, enforce=True, X=adata.layers['M_t'], V=adata.layers['velocity_alpha_minus_gamma_s'], method='cosine'); print('M_t' in adata.layers, 'velocity_T' in adata.layers, 'velocity_alpha_minus_gamma_s' in adata.layers, 'velocity_umap' in adata.obsm, 'cosine_transition_matrix' in adata.obsp)\"",
+      "timeout_seconds": 240,
+      "expect_stdout_contains": [
+        "True True True True True"
+      ]
+    },
+    {
+      "name": "combined-dynamics-branch",
+      "conda_env": "omictest",
+      "env": {
+        "PYTHONPATH": "/Users/fernandozeng/Desktop/analysis/dynamo-release",
+        "MPLCONFIGDIR": "/tmp/mpl",
+        "NUMBA_CACHE_DIR": "/tmp/numba"
+      },
+      "command": "${PYTHON} -c \"import anndata as ad, dynamo as dyn; raw=dyn.sample_data.hematopoiesis_raw(); selected=list(raw.uns['genes_to_use']); pairs=[('3','HSC',20),('5','HSC',20),('3','MEP-like',20),('5','MEP-like',20)]; parts=[raw[(raw.obs['time'].astype(str)==t) & (raw.obs['cell_type']==c)][:n].copy() for t,c,n in pairs]; adata=ad.concat(parts, merge='same', label='subset_group', keys=[f'{t}_{c}' for t,c,_ in pairs], index_unique='-'); adata.obs_names_make_unique(); adata.uns['genes_to_use']=selected; pre=dyn.pp.Preprocessor(force_gene_list=selected); pre.config_monocle_recipe(adata, n_top_genes=len(selected)); pre.preprocess_adata_monocle(adata, tkey='time', experiment_type='one-shot'); dyn.tl.reduceDimension(adata); dyn.tl.moments(adata, group='time'); adata.uns['pp']['has_splicing']=False; dyn.tl.dynamics(adata, group='time', one_shot_method='combined', model='deterministic', cores=1); print('velocity_T' in adata.layers, 'dynamics' in adata.uns, 'time_3_vel_params_names' in adata.uns, adata.uns['dynamics'].get('model'), adata.uns['dynamics'].get('est_method'))\"",
+      "timeout_seconds": 240,
+      "expect_stdout_contains": [
+        "True True True deterministic ols"
+      ]
+    }
+  ]
+}

--- a/skills/dynamo-one-shot-total-rna-velocity/references/branch-selection.md
+++ b/skills/dynamo-one-shot-total-rna-velocity/references/branch-selection.md
@@ -1,0 +1,183 @@
+# Branch Selection
+
+This notebook mixes sample-data assumptions, curated-gene preprocessing, time-group smoothing, one-shot kinetic fitting, custom total-RNA velocity calculation, and visualization. Use this reference to keep those stages separate instead of replaying every cell literally.
+
+## Default Job
+
+If the user asks to reproduce or adapt one-shot total RNA velocity in `dynamo`:
+
+1. inspect whether the input already has `new`, `total`, `time`, and an optional curated gene list
+2. preprocess with the monocle path
+3. run `moments(..., group='time')`
+4. force `adata.uns["pp"]["has_splicing"] = False`
+5. run `dynamics(..., one_shot_method='sci_fate', model='deterministic')`
+6. run `calculate_velocity_alpha_minus_gamma_s(...)`
+7. project with `cell_velocities(..., X=M_t, V=velocity_alpha_minus_gamma_s, method='cosine')`
+
+## Stage 1: Gene List And Preprocessing
+
+Relevant branch-heavy interfaces:
+
+- `Preprocessor.preprocess_adata(..., recipe='monocle')`
+- `Preprocessor.preprocess_adata_monocle(...)`
+- `Preprocessor.config_monocle_recipe(..., n_top_genes=...)`
+
+Observed `recipe` branches in current source:
+
+- `monocle`
+- `seurat`
+- `sctransform`
+- `pearson_residuals`
+- `monocle_pearson_residuals`
+
+Recommendation for this workflow family:
+
+- use `recipe='monocle'`
+- use `force_gene_list` plus `config_monocle_recipe(..., n_top_genes=len(gene_list))` when a curated list exists
+
+When to switch:
+
+- drop `force_gene_list` only when the user does not have a trusted notebook-derived or marker/HVG list
+- use another `recipe` only when the user explicitly wants that preprocessing family and accepts that the exact notebook path is no longer being reproduced
+
+Important runtime rule:
+
+- `anndata.concat(...)` can drop `uns["genes_to_use"]`
+- preserve the list explicitly before rebuilding subsets
+
+## Stage 2: Grouped Moments
+
+Relevant branch-heavy parameters on `dyn.tl.moments(...)`:
+
+- `group`
+- `use_gaussian_kernel`
+- `use_mnn`
+- `layers`
+
+Recommendation for this workflow family:
+
+- use `group='time'`
+- keep `use_gaussian_kernel=False`
+- keep `use_mnn=False`
+- keep `layers='all'`
+
+Reason:
+
+- the one-shot fit depends on smoothed `M_n`, `M_t`, and `M_s`
+- empirical notebook-adjacent execution populated those layers and `obsp["moments_con"]` through the default grouped branch
+
+When to switch:
+
+- omit `group` only when the user explicitly wants global smoothing without time-specific neighborhoods
+- use `use_mnn=True` only for batch-correction-aware neighbor logic, not as a default notebook conversion choice
+
+## Stage 3: Model-2 Kinetics
+
+Relevant branch-heavy parameters on `dyn.tl.dynamics(...)` for this workflow family:
+
+- `group`
+- `model`
+- `est_method`
+- `one_shot_method`
+
+Observed `one_shot_method` branches in current source:
+
+- `combined`
+- `sci-fate`
+- `sci_fate`
+
+Observed `model` branches in current source include:
+
+- `deterministic`
+- `stochastic`
+- `mixture`
+- `model_selection`
+
+Recommendation for this workflow family:
+
+- set `adata.uns["pp"]["has_splicing"] = False`
+- use `group='time'`
+- use `one_shot_method='sci_fate'`
+- use `model='deterministic'`
+
+Why:
+
+- this reproduces the tutorial's Model-2 path
+- empirically checked `sci_fate` and `combined` branches both succeeded on the hematopoiesis sample
+- the default deterministic one-shot runs stored `velocity_T` and `est_method='ols'`
+
+When to switch:
+
+- use `one_shot_method='combined'` when the user explicitly wants the steady-state-plus-absolute-gamma branch
+- do not silently switch to a splicing-aware model when the goal is total RNA velocity from the tutorial
+
+Important storage rule:
+
+- current runtime does not store the chosen `one_shot_method` in `adata.uns["dynamics"]`
+- document the branch choice in your own workflow notes if later interpretation depends on it
+
+## Stage 4: Total RNA Velocity Layer
+
+Relevant interface:
+
+- `calculate_velocity_alpha_minus_gamma_s(adata, gene_subset_key='use_for_pca', velocity_layer_name='velocity_alpha_minus_gamma_s')`
+
+Recommendation:
+
+- keep the default `gene_subset_key='use_for_pca'`
+- keep the default output layer name unless the user explicitly wants a separate comparison run
+
+Important runtime rules:
+
+- the function requires `adata.obs["time"]`
+- it reads `adata.layers["M_n"]` and `adata.layers["M_s"]`
+- it expects per-time kinetic parameters already written by `dynamics(...)`
+
+## Stage 5: Low-Dimensional Projection
+
+Relevant branch-heavy parameters on `dyn.tl.cell_velocities(...)`:
+
+- `method`: `kmc`, `fp`, `cosine`, `pearson`, `transform`
+- `basis`
+- `adj_key`
+
+Recommendation for this workflow family:
+
+- use `basis='umap'`
+- use `X=adata.layers["M_t"]`
+- use `V=adata.layers["velocity_alpha_minus_gamma_s"]`
+- use `method='cosine'` for notebook parity
+
+When to switch:
+
+- use `method='pearson'` when the user wants the alternate correlation-style kernel
+- use `method='transform'` only when `adata.uns["umap_fit"]` already exists
+- use `kmc` or `fp` only when the user explicitly wants those Markov or operator branches and understands the extra tuning surface
+
+Important storage rules:
+
+- `cosine` writes `adata.obsp["cosine_transition_matrix"]`
+- `pearson` writes `adata.obsp["pearson_transition_matrix"]`
+- both empirically checked branches populated `adata.obsm["velocity_umap"]`
+
+## Stage 6: Visualization
+
+Relevant branch-heavy plotting parameters:
+
+- `streamline_plot(..., method='gaussian' | 'SparseVFC')`
+- `phase_portraits(..., show_quiver=False | True, use_smoothed=True | False, ...)`
+
+Recommendation:
+
+- use `streamline_plot(..., method='gaussian')` after `velocity_umap` exists
+- treat phase portraits as an optional interpretation branch, not part of the execution spine
+
+## Decision Rule
+
+If the user asks for:
+
+- "the notebook result" -> run the default job and keep the curated-gene-list branch if available
+- "just the kinetic fit" -> stop after `dynamics(...)` and report that no low-dimensional total-RNA velocity has been projected yet
+- "total RNA velocity on UMAP" -> continue through `calculate_velocity_alpha_minus_gamma_s(...)` and `cell_velocities(...)`
+- "why projection changed" -> compare `method='cosine'` and `method='pearson'`
+- "why my subset fails" -> first check whether `genes_to_use` was lost and whether each time group has enough cells

--- a/skills/dynamo-one-shot-total-rna-velocity/references/compatibility.md
+++ b/skills/dynamo-one-shot-total-rna-velocity/references/compatibility.md
@@ -1,0 +1,88 @@
+# Compatibility
+
+Use this reference when notebook wording and current source behavior differ.
+
+## Sample Data Layout
+
+Observed on current `dyn.sample_data.hematopoiesis_raw()`:
+
+- `.obs` includes `batch`, `cell_type`, `time`
+- `.layers` includes `new`, `spliced`, `total`, `unspliced`
+- `.obsm` already includes `X_umap`
+- `.uns` includes `genes_to_use`
+
+Conservative rule:
+
+- treat these as worked-example conveniences, not guarantees for unrelated one-shot labeling data
+
+## Curated Gene List Persistence
+
+Observed current behavior:
+
+- `anndata.concat(...)` dropped `uns["genes_to_use"]` during empirical subset reconstruction
+
+Conservative rule:
+
+- preserve the gene list explicitly before concatenating or rebuilding subsets
+
+## Model-2 Forcing
+
+Notebook prose:
+
+- the tutorial wants the no-splicing Model-2 branch even though the raw object includes splicing layers
+
+Observed current behavior:
+
+- preprocessing auto-detected both labeling and splicing on the hematopoiesis raw object
+- empirical notebook parity required `adata.uns["pp"]["has_splicing"] = False` before `dynamics(...)`
+
+Conservative rule:
+
+- do not skip the explicit `has_splicing=False` override when reproducing the tutorial's total-RNA path
+
+## Output-Key Mismatch
+
+Notebook implication:
+
+- `dynamics(...)` is only the setup for total-RNA velocity, not the final projected result
+
+Observed current behavior:
+
+- empirically checked `dynamics(...)` wrote `velocity_N` and `velocity_T`
+- it did not write `velocity_S`
+- the notebook-like visualization path relied on `velocity_alpha_minus_gamma_s` plus `velocity_umap`
+
+Conservative rule:
+
+- do not stop at `velocity_T` if the user asked for the tutorial's low-dimensional total-RNA velocity output
+
+## Time-Key Requirement
+
+Observed current behavior:
+
+- `calculate_velocity_alpha_minus_gamma_s(...)` reads `adata.obs["time"]` directly
+
+Conservative rule:
+
+- rename or copy any alternate time key to `time` before calling the function
+
+## Projection Storage
+
+Observed current behavior:
+
+- `method='cosine'` stores `adata.obsp["cosine_transition_matrix"]`
+- `method='pearson'` stores `adata.obsp["pearson_transition_matrix"]`
+
+Conservative rule:
+
+- do not look for a generic transition-matrix key after projection
+
+## Small Time Groups
+
+Observed current behavior:
+
+- reviewer runs with fewer than `50` cells per time group emitted NaN warnings and filtered genes before projection
+
+Conservative rule:
+
+- prefer coarser groups or more cells per time point before trusting downstream velocity visualization

--- a/skills/dynamo-one-shot-total-rna-velocity/references/source-grounding.md
+++ b/skills/dynamo-one-shot-total-rna-velocity/references/source-grounding.md
@@ -1,0 +1,239 @@
+# Source Grounding
+
+This skill was generated from live code inspection and empirical execution on the hematopoiesis worked example, not from notebook prose alone.
+
+## Inspection Notes
+
+Source inspection and empirical checks were performed in a local Python runtime compatible with this repository's dependencies.
+
+## Primary Source Files
+
+Notebook inspected:
+
+- `docs/tutorials/notebooks/301_tutorial_hsc_velocity.ipynb`
+
+Code inspected:
+
+- `dynamo.preprocessing.Preprocessor`
+- `dynamo.tools.moments`
+- `dynamo.tools.dynamics`
+- `dynamo.tools.cell_velocities`
+- `dynamo.plot.scatters`
+
+## Inspected Interfaces
+
+### `Preprocessor.config_monocle_recipe`
+
+Observed signature:
+
+```python
+(self, adata, n_top_genes=2000) -> None
+```
+
+### `Preprocessor.preprocess_adata_monocle`
+
+Observed signature:
+
+```python
+(self, adata, tkey=None, experiment_type=None)
+```
+
+### `Preprocessor.preprocess_adata`
+
+Observed signature:
+
+```python
+(self, adata, recipe='monocle', tkey=None, experiment_type=None)
+```
+
+Observed `recipe` branches in current source:
+
+- `monocle`
+- `seurat`
+- `sctransform`
+- `pearson_residuals`
+- `monocle_pearson_residuals`
+
+### `dyn.tl.moments`
+
+Observed signature:
+
+```python
+(adata, X_data=None, genes=None, group=None, conn=None, use_gaussian_kernel=False, normalize=True, use_mnn=False, layers='all', n_pca_components=30, n_neighbors=30, copy=False)
+```
+
+Important source detail:
+
+- the function writes `adata.obsp["moments_con"]`
+- for this labeling workflow it also materializes `M_n`, `M_t`, `M_s`, and related second-moment layers
+
+### `dyn.tl.dynamics`
+
+Observed signature includes:
+
+```python
+(adata, ..., model='auto', est_method='auto', ..., group=None, ..., one_shot_method='combined', ...)
+```
+
+Observed `one_shot_method` branches:
+
+- `combined`
+- `sci-fate`
+- `sci_fate`
+
+Observed source-level `model` branches include:
+
+- `deterministic`
+- `stochastic`
+- `mixture`
+- `model_selection`
+
+Important source details:
+
+- the docstring describes `sci-fate` as the direct first-order decay fit and `combined` as the steady-state-plus-absolute-gamma route
+- the one-shot branch choice is not stored back into `adata.uns["dynamics"]` on the checked runtime
+
+### `calculate_velocity_alpha_minus_gamma_s`
+
+Observed signature:
+
+```python
+(adata, gene_subset_key='use_for_pca', velocity_layer_name='velocity_alpha_minus_gamma_s')
+```
+
+Important source details:
+
+- requires `gene_subset_key` to exist in `adata.var`
+- hard-codes `adata.obs.time.astype(float)`
+- reads `adata[:, pca_genes].layers["M_n"]`
+- reads `adata.layers["M_s"][:, pca_genes_array]`
+- looks up time-specific gamma parameters and writes `adata.layers[velocity_layer_name]`
+
+### `dyn.tl.cell_velocities`
+
+Observed signature includes:
+
+```python
+(adata, ..., X=None, V=None, basis='umap', adj_key='distances', ..., method='pearson', ...)
+```
+
+Observed `method` branches:
+
+- `kmc`
+- `fp`
+- `cosine`
+- `pearson`
+- `transform`
+
+Important source details:
+
+- `method in ['pearson', 'cosine']` stores `adata.obsp["<method>_transition_matrix"]`
+- `method='transform'` depends on `adata.uns["umap_fit"]`
+
+### `dyn.pl.streamline_plot`
+
+Observed signature includes:
+
+```python
+(..., basis='umap', method='gaussian', ...)
+```
+
+Observed `method` branches:
+
+- `gaussian`
+- `SparseVFC`
+
+### `dyn.pl.phase_portraits`
+
+Observed signature includes:
+
+```python
+(adata, genes, ..., vkey=None, ekey=None, basis='umap', ..., use_smoothed=True, ...)
+```
+
+## Empirical Checks Run
+
+### Sample Data Load
+
+Observed on current `dyn.sample_data.hematopoiesis_raw()`:
+
+- shape is `1947 x 26193`
+- `.obs` includes `batch`, `cell_type`, `time`
+- `.layers` includes `new`, `spliced`, `total`, `unspliced`
+- `.obsm` includes `X_umap`
+- `.uns` includes `genes_to_use`
+- `genes_to_use` length is `2552`
+- unique `time` values are `3` and `5`
+
+Worked-example note:
+
+- these metadata names are useful for reproducing the tutorial
+- they are not universal assumptions for all one-shot labeling inputs
+
+### Notebook-Like Core Path
+
+Checked on a `224`-cell subset across `HSC`, `MEP-like`, and `Mon` at time `3` and `5`:
+
+1. preserve `raw.uns["genes_to_use"]` before concatenation
+2. `Preprocessor(force_gene_list=selected)`
+3. `config_monocle_recipe(..., n_top_genes=len(selected))`
+4. `preprocess_adata_monocle(..., tkey='time', experiment_type='one-shot')`
+5. `reduceDimension(...)`
+6. `moments(..., group='time')`
+7. set `adata.uns["pp"]["has_splicing"] = False`
+8. `dynamics(..., group='time', one_shot_method='sci_fate', model='deterministic')`
+9. `calculate_velocity_alpha_minus_gamma_s(...)`
+10. `cell_velocities(..., X=M_t, V=velocity_alpha_minus_gamma_s, method='cosine')`
+
+Observed outputs:
+
+- concatenation dropped `uns["genes_to_use"]` until it was restored manually
+- preprocessing started from the `2552`-gene curated list, reported `1925` genes in use, and ended with `1292` `use_for_pca` genes
+- `reduceDimension(...)` reused the existing UMAP basis and created `obsp["connectivities"]` and `obsp["distances"]`
+- `moments(...)` created `M_n`, `M_t`, `M_s`, related second moments, and `obsp["moments_con"]`
+- `dynamics(...)` created `velocity_N`, `velocity_T`, `use_for_dynamics`, and time-specific parameter-name keys
+- `dynamics(...)` did not create `velocity_S`
+- `calculate_velocity_alpha_minus_gamma_s(...)` created `adata.layers["velocity_alpha_minus_gamma_s"]` and processed both time points
+- `cell_velocities(..., method='cosine')` created `adata.obsm["velocity_umap"]` and `adata.obsp["cosine_transition_matrix"]`
+
+Observed runtime warning with this path:
+
+- `641` genes were removed because of NaN velocity values before the cosine projection
+
+### Alternate `combined` One-Shot Branch
+
+Checked on an `80`-cell subset across `HSC` and `MEP-like` at time `3` and `5`:
+
+1. same preprocessing and grouped-moments path
+2. set `adata.uns["pp"]["has_splicing"] = False`
+3. `dynamics(..., group='time', one_shot_method='combined', model='deterministic')`
+
+Observed outputs:
+
+- `velocity_T` existed
+- `adata.uns["dynamics"]["model"] == "deterministic"`
+- `adata.uns["dynamics"]["est_method"] == "ols"`
+
+### Alternate `pearson` Projection Branch
+
+Checked on an `80`-cell subset across `HSC` and `MEP-like` at time `3` and `5`:
+
+1. same `sci_fate` deterministic total-RNA path through `calculate_velocity_alpha_minus_gamma_s(...)`
+2. `cell_velocities(..., X=M_t, V=velocity_alpha_minus_gamma_s, method='pearson')`
+
+Observed outputs:
+
+- `adata.obsm["velocity_umap"]`
+- `adata.obsp["pearson_transition_matrix"]`
+
+### Small-Group Warning
+
+Observed on the checked `80`-cell branch:
+
+- `dynamics(...)` warned that groups with fewer than `50` cells may produce all-NaN velocities for some cells and downstream issues
+
+## Human Review Notes
+
+- The stable reusable job is one-shot total RNA velocity, not "run the HSC notebook."
+- The highest-signal compatibility traps are preserving `genes_to_use`, forcing `has_splicing=False` for the Model-2 branch, and keeping the time column under the literal key `time`.
+- The notebook's real endpoint is the custom total-RNA projection branch, not the raw `dynamics(...)` output alone.

--- a/skills/dynamo-one-shot-total-rna-velocity/references/source-notebook-map.md
+++ b/skills/dynamo-one-shot-total-rna-velocity/references/source-notebook-map.md
@@ -1,0 +1,175 @@
+# Source Notebook Map
+
+Source notebook:
+`docs/tutorials/notebooks/301_tutorial_hsc_velocity.ipynb`
+
+Use this file to see how the hematopoiesis scNT-seq tutorial was converted into a reusable one-shot total RNA velocity skill.
+
+Conversion rule used here:
+
+- the stable skill identity is one-shot total RNA velocity in `dynamo`
+- hematopoiesis remains the worked example notebook and sample dataset, not the trigger surface
+
+## Notebook Sections To Skill Responsibilities
+
+### 1. Setup And Sample-Data Loading
+
+Notebook role:
+
+- import `dynamo`
+- set plotting style
+- load `dyn.sample_data.hematopoiesis_raw()`
+
+Preserved in the skill:
+
+- `SKILL.md` Quick Workflow
+- `SKILL.md` Minimal Execution Patterns
+- `references/source-grounding.md`
+
+Intentionally dropped:
+
+- warning filters
+- plotting-style boilerplate
+
+### 2. Predefined Gene List
+
+Notebook role:
+
+- read `adata_hsc_raw.uns["genes_to_use"]`
+
+Preserved in the skill:
+
+- `SKILL.md` Quick Workflow
+- `SKILL.md` Branch Selection
+- `references/compatibility.md`
+
+Source-grounded addition:
+
+- `anndata.concat(...)` can drop `uns["genes_to_use"]`, so the reusable skill calls out explicit preservation during subset reconstruction
+
+### 3. Monocle Preprocessing
+
+Notebook role:
+
+- instantiate `Preprocessor(force_gene_list=selected_genes_to_use)`
+- call `config_monocle_recipe(..., n_top_genes=len(selected_genes_to_use))`
+- call `preprocess_adata_monocle(..., tkey="time", experiment_type="one-shot")`
+
+Preserved in the skill:
+
+- `SKILL.md` Interface Summary
+- `SKILL.md` Minimal Execution Patterns
+- `references/branch-selection.md`
+
+Source-grounded addition:
+
+- current `Preprocessor` source also exposes higher-level `preprocess_adata(..., recipe='monocle', ...)` and other recipe branches
+
+### 4. Embedding And Grouped Moments
+
+Notebook role:
+
+- call `dyn.tl.reduceDimension(...)`
+- call `dyn.tl.moments(..., group="time")`
+
+Preserved in the skill:
+
+- `SKILL.md` Quick Workflow
+- `SKILL.md` Validation
+- `references/branch-selection.md`
+
+Source-grounded addition:
+
+- `moments(...)` is where `M_n`, `M_t`, `M_s`, and `moments_con` are created for this workflow
+
+### 5. Force Model 2 And Fit Kinetics
+
+Notebook role:
+
+- set `adata_hsc_raw.uns["pp"]["has_splicing"] = False`
+- run `dyn.tl.dynamics(..., group="time", one_shot_method="sci_fate", model="deterministic")`
+
+Preserved in the skill:
+
+- `SKILL.md` Quick Workflow
+- `SKILL.md` Branch Selection
+- `references/compatibility.md`
+
+Source-grounded additions:
+
+- `one_shot_method='combined'` is a real alternate branch
+- current runtime does not store the chosen `one_shot_method` in `adata.uns["dynamics"]`
+
+### 6. Calculate Total RNA Velocity
+
+Notebook role:
+
+- run `dyn.tl.calculate_velocity_alpha_minus_gamma_s(adata_hsc_raw)`
+
+Preserved in the skill:
+
+- `SKILL.md` Interface Summary
+- `SKILL.md` Validation
+- `references/source-grounding.md`
+
+Source-grounded additions:
+
+- current source hard-codes `adata.obs["time"]`
+- current source reads `M_n` and `M_s` and writes `velocity_alpha_minus_gamma_s`
+
+### 7. Project To UMAP
+
+Notebook role:
+
+- run `dyn.tl.cell_velocities(..., X=M_t, V=velocity_alpha_minus_gamma_s, method="cosine")`
+
+Preserved in the skill:
+
+- `SKILL.md` Minimal Execution Patterns
+- `references/branch-selection.md`
+
+Source-grounded addition:
+
+- `cell_velocities` has more kernel branches than the notebook uses and stores kernel-specific transition-matrix keys
+
+### 8. Visualization
+
+Notebook role:
+
+- `dyn.pl.streamline_plot(...)`
+- markdown-only note about phase diagrams
+
+Preserved in the skill:
+
+- `references/visualization-and-phase-portraits.md`
+
+Intentional downgrade:
+
+- streamline plotting is retained as an optional post-analysis branch
+- phase portraits are documented as an inference-backed adaptation because the executed code cell is not present in the extracted notebook content
+
+## Source-Grounded Additions Beyond The Notebook
+
+These details were added from live source inspection and empirical execution, not notebook prose alone:
+
+- recipe branches exposed by `Preprocessor`
+- `moments(...)` output keys and grouped-smoothing behavior
+- `dynamics(...)` one-shot branch coverage for `sci_fate` and `combined`
+- the fact that `velocity_T` exists after `dynamics(...)` but `velocity_S` does not on the checked Model-2 path
+- the hard requirement that `calculate_velocity_alpha_minus_gamma_s(...)` sees `adata.obs["time"]`
+- kernel-specific output keys for `cell_velocities(...)`
+
+## What Was Intentionally Not Carried Over
+
+- tutorial narration about published figures
+- warning-filter boilerplate
+- display-only notebook setup
+- unsupported claims about the exact phase-portrait cell that was not present in the extracted notebook JSON
+
+## When To Reopen The Notebook
+
+Reopen the notebook only when:
+
+- the user wants exact figure-text parity with the tutorial prose
+- a newer notebook revision includes the missing phase-portrait code cell
+- the tutorial starts using a different one-shot estimator or storage convention

--- a/skills/dynamo-one-shot-total-rna-velocity/references/visualization-and-phase-portraits.md
+++ b/skills/dynamo-one-shot-total-rna-velocity/references/visualization-and-phase-portraits.md
@@ -1,0 +1,74 @@
+# Visualization And Phase Portraits
+
+Use this reference only when the user explicitly wants notebook-style figures after the analytical workflow has already populated `velocity_umap` or the total-RNA velocity layer.
+
+## Streamline Plot
+
+Primary entrypoint:
+
+- `dyn.pl.streamline_plot(...)`
+
+Recommended prerequisites:
+
+1. `dyn.tl.cell_velocities(..., X=adata.layers["M_t"], V=adata.layers["velocity_alpha_minus_gamma_s"])`
+2. a matching low-dimensional embedding such as `adata.obsm["X_umap"]`
+
+Notebook-like call:
+
+```python
+dyn.pl.streamline_plot(
+    adata,
+    color=["batch", "cell_type", "PF4"],
+    ncols=2,
+    basis="umap",
+    s_kwargs_dict={"adjust_legend": True, "dpi": 80},
+    figsize=(4, 4),
+)
+```
+
+Observed plotting `method` branches in current source:
+
+- `gaussian`
+- `SparseVFC`
+
+Recommendation:
+
+- keep `method='gaussian'` unless the user explicitly wants a vector-field-backed streamline rendering
+
+## Total RNA Phase Portraits
+
+Primary entrypoint:
+
+- `dyn.pl.phase_portraits(...)`
+
+The notebook ends with phase-diagram prose but does not include the executed code cell in the extracted source. The adaptation below is an inference from the current `phase_portraits` signature plus the notebook's total-RNA execution spine.
+
+Inference-backed total-RNA adaptation:
+
+```python
+dyn.pl.phase_portraits(
+    adata,
+    genes=["PF4"],
+    ekey="M_t",
+    vkey="velocity_alpha_minus_gamma_s",
+    color="cell_type",
+    basis="umap",
+    use_smoothed=True,
+)
+```
+
+Why this inference is reasonable:
+
+- the notebook's analytical path produces total-RNA expression in `M_t`
+- the custom velocity layer is `velocity_alpha_minus_gamma_s`
+- relying on splicing defaults would not match the notebook's total-RNA branch
+
+Conservative rule:
+
+- label this as an adaptation unless the user provides a newer notebook revision with the exact phase-portrait cell
+
+## Constraints
+
+- Do not let plotting block the main analytical workflow.
+- Do not assume `streamline_plot(...)` itself computes the total-RNA velocity layer; it only visualizes the outputs already present on `adata`.
+- Do not reuse notebook font, style, or background tweaks unless the user explicitly wants presentation parity.

--- a/skills/dynamo-preprocess/SKILL.md
+++ b/skills/dynamo-preprocess/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: dynamo-preprocess
+description: Run or adapt dynamo preprocessing with `dynamo.preprocessing.Preprocessor`, including the `recipe` branches `monocle`, `seurat`, `sctransform`, `pearson_residuals`, and `monocle_pearson_residuals`. Use when converting or reproducing `docs/tutorials/notebooks/100_tutorial_preprocess.ipynb`, preprocessing an `AnnData` object for downstream dynamo analysis, customizing preprocessing kwargs, or translating notebook-level preprocessing into a reusable agent workflow.
+---
+
+# Dynamo Preprocess
+
+## Goal
+
+Preprocess an `AnnData` object with the current `dynamo.preprocessing.Preprocessor` API, choose the correct `recipe` branch for the downstream task, customize kwargs before execution when needed, and validate that the expected keys and embeddings exist for later dynamo analysis.
+
+## Quick Workflow
+
+1. Inspect the user's data, environment, and downstream goal.
+2. Choose the `recipe` branch that matches the goal instead of defaulting blindly to the notebook's first example.
+3. Use `Preprocessor.preprocess_adata(...)` for the common case.
+4. If the user needs customization, call `config_*_recipe(...)`, mutate kwargs, then run the matching recipe-specific method.
+5. If the user needs debugging or a custom pipeline, run the preprocessing steps individually in notebook order.
+6. Validate `obs`, `var`, `layers`, and `obsm` keys before treating preprocessing as complete.
+
+## Interface Summary
+
+- `Preprocessor.preprocess_adata(adata, recipe='monocle', tkey=None, experiment_type=None)` is the main wrapper.
+- The live source dispatches `recipe` across five branches:
+  `monocle`, `seurat`, `sctransform`, `pearson_residuals`, `monocle_pearson_residuals`.
+- `config_monocle_recipe(adata, n_top_genes=2000)` is the only recipe config in this notebook family that exposes an extra tuning argument directly in the signature.
+- The constructor exposes many overridable callables and kwargs dictionaries, but the notebook mainly mutates:
+  `filter_cells_by_outliers_kwargs`, `filter_genes_by_outliers_kwargs`, and `select_genes_kwargs`.
+
+Read `references/source-grounding.md` before documenting parameters in more detail or when you need the exact inspected signatures.
+
+## Recipe Selection
+
+- Use `monocle` as the default when the goal is standard dynamo preprocessing for velocity or vector-field analysis.
+- Use `seurat` when the user specifically wants Seurat-style highly variable gene selection inside the current `Preprocessor` wrapper.
+- Use `sctransform` only when the user explicitly wants that transformation and the environment has `KDEpy`.
+- Use `pearson_residuals` when the goal is HVG selection and PCA on `adata.X`, not layer-preserving velocity normalization.
+- Use `monocle_pearson_residuals` when the user wants Pearson-residual-based feature selection and PCA but still needs monocle-style normalized layers for downstream velocity analysis.
+
+Read `references/recipe-selection.md` before choosing a non-default `recipe`.
+
+## Minimal Execution Patterns
+
+For the common case, use the wrapper:
+
+```python
+import dynamo as dyn
+from dynamo.preprocessing import Preprocessor
+
+adata = dyn.sample_data.zebrafish()
+preprocessor = Preprocessor()
+preprocessor.preprocess_adata(adata, recipe="monocle")
+dyn.tl.reduceDimension(adata, basis="pca")
+```
+
+For recipe customization, configure first, then mutate kwargs, then run the matching method:
+
+```python
+import numpy as np
+from dynamo.preprocessing import Preprocessor
+
+preprocessor = Preprocessor()
+preprocessor.config_monocle_recipe(adata)
+
+preprocessor.filter_cells_by_outliers_kwargs = {
+    "filter_bool": None,
+    "layer": "all",
+    "min_expr_genes_s": 300,
+    "min_expr_genes_u": 100,
+    "min_expr_genes_p": 50,
+    "max_expr_genes_s": np.inf,
+    "max_expr_genes_u": np.inf,
+    "max_expr_genes_p": np.inf,
+    "shared_count": None,
+}
+
+preprocessor.select_genes_kwargs = {
+    "n_top_genes": 2500,
+    "sort_by": "cv_dispersion",
+    "keep_filtered": True,
+    "SVRs_kwargs": {
+        "relative_expr": True,
+        "total_szfactor": "total_Size_Factor",
+        "min_expr_cells": 0,
+        "min_expr_avg": 0,
+        "max_expr_avg": np.inf,
+        "winsorize": False,
+        "winsor_perc": (1, 99.5),
+        "sort_inverse": False,
+        "svr_gamma": None,
+    },
+}
+
+preprocessor.preprocess_adata_monocle(adata)
+```
+
+For direct stepwise execution, follow the notebook spine:
+
+1. `pp.standardize_adata(adata, tkey, experiment_type)`
+2. `pp.filter_cells_by_outliers(...)`
+3. `pp.filter_genes_by_outliers(...)`
+4. `pp.normalize_by_cells(...)`
+5. `pp.select_genes(...)`
+6. `pp.norm_method(...)`
+7. `pp.pca(...)`
+8. `dyn.tl.reduceDimension(adata, basis="pca")`
+
+Use the stepwise path for debugging or nonstandard workflows, not as the default wrapper replacement.
+
+## Validation
+
+After preprocessing, check these items:
+
+- `adata.obs` may contain QC keys such as `pass_basic_filter`, `Size_Factor`, `nGenes`, `nCounts`, and `pMito`.
+- `adata.var` may contain `pass_basic_filter`, `use_for_pca`, and recipe-specific variability metrics.
+- `adata.obsm["X_pca"]` should exist after PCA-based recipes.
+- Layer-preserving workflows may create normalized layers such as `X_spliced` and `X_unspliced`.
+- `dyn.tl.reduceDimension(adata, basis="pca")` should run without shape or key errors.
+
+If notebook-style visualization parity matters, the standard post-check is:
+
+```python
+dyn.tl.reduceDimension(adata, basis="pca")
+dyn.pl.umap(adata, color=celltype_key)
+```
+
+## Constraints
+
+- Do not assume the notebook covers every `recipe` branch; the live source adds `monocle_pearson_residuals` as a distinct hybrid path.
+- Pearson residuals and sctransform are intended for `adata.X`; using them on velocity-relevant layers can create downstream problems.
+- `sctransform` requires `KDEpy`.
+- `dyn.sample_data.zebrafish()` may require data download if the dataset is not cached.
+- Prefer the current `dynamo.preprocessing.Preprocessor` API over older recipe helpers unless the user explicitly asks for legacy behavior.
+
+## Resource Map
+
+- Read `references/recipe-selection.md` for branch-by-branch guidance.
+- Read `references/source-notebook-map.md` to trace each part of the notebook to the generated skill.
+- Read `references/source-grounding.md` for inspected signatures, doc-derived notes, and source-level `recipe` branch evidence.
+- Read `references/compatibility.md` when notebook prose and current source behavior may have drifted.

--- a/skills/dynamo-preprocess/assets/acceptance.json
+++ b/skills/dynamo-preprocess/assets/acceptance.json
@@ -1,0 +1,54 @@
+{
+  "version": 1,
+  "skill": "dynamo-preprocess",
+  "sample_requests": [
+    "Help me preprocess an AnnData object for downstream dynamo analysis",
+    "Convert the preprocess tutorial notebook into an executable workflow using the current Preprocessor API"
+  ],
+  "required_description_terms": [
+    "dynamo",
+    "preprocessor",
+    "recipe",
+    "anndata",
+    "notebooks",
+    "kwargs"
+  ],
+  "required_sections": [
+    "## Goal",
+    "## Quick Workflow",
+    "## Interface Summary",
+    "## Recipe Selection",
+    "## Validation",
+    "## Resource Map"
+  ],
+  "required_body_terms": [
+    "preprocess_adata",
+    "recipe",
+    "monocle_pearson_residuals",
+    "source-grounding",
+    "x_pca",
+    "reduceDimension"
+  ],
+  "required_paths": [
+    "references/recipe-selection.md",
+    "references/source-notebook-map.md",
+    "references/source-grounding.md",
+    "references/compatibility.md"
+  ],
+  "smoke_commands": [
+    {
+      "name": "import-preprocessor-interface",
+      "conda_env": "omictest",
+      "env": {
+        "MPLCONFIGDIR": "/tmp/mpl",
+        "NUMBA_CACHE_DIR": "/tmp/numba"
+      },
+      "command": "${PYTHON} -c \"import numpy as np; import anndata as ad; from dynamo.preprocessing import Preprocessor; adata = ad.AnnData(X=np.abs(np.random.poisson(1, (20, 10))).astype(float)); p = Preprocessor(); print(Preprocessor.__name__); print(hasattr(p, 'preprocess_adata'))\"",
+      "timeout_seconds": 120,
+      "expect_stdout_contains": [
+        "Preprocessor",
+        "True"
+      ]
+    }
+  ]
+}

--- a/skills/dynamo-preprocess/references/compatibility.md
+++ b/skills/dynamo-preprocess/references/compatibility.md
@@ -1,0 +1,34 @@
+# Compatibility
+
+Use this reference when notebook wording and current source behavior may not be identical.
+
+## Current API Preference
+
+Prefer:
+
+- `dynamo.preprocessing.Preprocessor`
+
+Do not default to older helpers such as:
+
+- `dynamo.pp.recipe_monocle`
+
+unless the user explicitly asks for legacy behavior.
+
+## Source Vs Notebook
+
+- The notebook is centered on current `Preprocessor` usage, but live source now clearly exposes the extra `recipe` branch `monocle_pearson_residuals`.
+- The generated skill therefore includes that branch even though it is not a main notebook section.
+
+## Runtime Constraints
+
+- `sctransform` requires `KDEpy`.
+- `dyn.sample_data.zebrafish()` may need a network or cached dataset in the runtime environment.
+- importing dynamo in this workspace is most stable in a repository-compatible Python environment with writable cache directories for matplotlib and numba.
+
+## Conservative Rule
+
+If notebook text and current source disagree:
+
+1. trust the current source for executable behavior
+2. mention the drift explicitly
+3. reopen the notebook only if figure parity or historical reproduction is the real goal

--- a/skills/dynamo-preprocess/references/recipe-selection.md
+++ b/skills/dynamo-preprocess/references/recipe-selection.md
@@ -1,0 +1,148 @@
+# Recipe Selection
+
+This reference summarizes the `recipe` branches used by `dynamo.preprocessing.Preprocessor.preprocess_adata(...)` for `docs/tutorials/notebooks/100_tutorial_preprocess.ipynb`.
+
+## Source-Grounded Branch List
+
+The live source for `Preprocessor.preprocess_adata(...)` dispatches `recipe` across five values:
+
+- `monocle`
+- `seurat`
+- `sctransform`
+- `pearson_residuals`
+- `monocle_pearson_residuals`
+
+The notebook explicitly demonstrates the first four. The fifth branch, `monocle_pearson_residuals`, is in current source and should not be omitted when documenting the workflow.
+
+## Default Choice
+
+Use `monocle` unless the user has a concrete reason to choose a different branch.
+
+It is the safest general-purpose preprocessing route when the downstream goal includes velocity, vector field analysis, or layer-preserving normalization.
+
+## Branch Summary
+
+### `monocle`
+
+Use when:
+
+- the user wants the standard dynamo preprocessing path
+- downstream work includes velocity or vector field analysis
+- layer-preserving normalization matters
+
+Core source-level sequence:
+
+1. `standardize_adata`
+2. filter cells
+3. filter genes
+4. size-factor calculation
+5. normalize by cells
+6. select genes
+7. append / exclude / force gene lists
+8. `log1p`
+9. optional regress-out
+10. PCA
+11. new-to-total ratio
+12. cell cycle scoring
+
+### `seurat`
+
+Use when:
+
+- the user wants Seurat-style HVG selection
+- the user still wants a mostly monocle-shaped pipeline
+
+Source-grounded differences from `monocle`:
+
+- `config_seurat_recipe(...)` calls `config_monocle_recipe(...)` first
+- then swaps `select_genes` to `select_genes_by_seurat_recipe`
+- uses `algorithm="seurat_dispersion"`
+- tightens `filter_genes_by_outliers_kwargs` to `{"shared_count": 20}`
+
+### `sctransform`
+
+Use when:
+
+- the user explicitly requests sctransform
+- the runtime has `KDEpy`
+
+Important behavior:
+
+- subsets genes for efficiency before running sctransform
+- writes PCA with `n_pca_components=50`
+- is not the safest default for velocity-preserving workflows
+
+Important warning from source behavior:
+
+- the recipe warns that if you want to avoid the built-in preliminary subsetting, you should run sctransform without this recipe wrapper
+
+### `pearson_residuals`
+
+Use when:
+
+- the goal is Pearson-residual-driven HVG selection and PCA on `adata.X`
+- the main objective is dimensionality reduction or exploratory preprocessing
+
+Important behavior:
+
+- disables standard cell and gene outlier filtering functions
+- uses `select_genes_by_pearson_residuals`
+- normalizes selected genes via `normalize_layers_pearson_residuals`
+- filters cells by highly variable genes
+- runs PCA with `n_pca_components=50`
+
+### `monocle_pearson_residuals`
+
+Use when:
+
+- the user wants Pearson-residual feature selection and PCA
+- the user still needs monocle-style normalized layers for downstream velocity and vector field workflows
+
+Why it matters:
+
+- source docstring explicitly says pure Pearson residual output can contain negative values that are undesirable for later RNA velocity analysis
+- this hybrid branch preserves monocle normalization while still using Pearson residuals for feature selection and PCA
+
+## Stepwise Customization
+
+Use direct stepwise calls only when:
+
+- the user wants to tune thresholds manually
+- the user wants to replace part of the recipe
+- the user wants debugging visibility at each stage
+
+Typical manual sequence from the notebook:
+
+1. `pp.standardize_adata(...)`
+2. `pp.filter_cells_by_outliers(...)`
+3. `pp.filter_genes_by_outliers(...)`
+4. `pp.normalize_by_cells(...)`
+5. `pp.select_genes(...)`
+6. `pp.norm_method(...)`
+7. `pp.pca(...)`
+
+For monocle-style behavior, do not forget that the wrapped recipe also performs size-factor calculation before normalization.
+
+## Common Validation Targets
+
+Check these after execution:
+
+- `adata.var["use_for_pca"]`
+- `adata.obsm["X_pca"]`
+- expected normalized layers for velocity-safe workflows
+- successful `dyn.tl.reduceDimension(adata, basis="pca")`
+- successful UMAP plotting with the chosen color key
+
+## Decision Rule
+
+If the user does not mention a branch:
+
+- default to `monocle`
+
+If the user asks for Pearson residuals but also cares about velocity layers:
+
+- prefer `monocle_pearson_residuals`
+
+If the user asks for notebook parity cell-by-cell:
+
+- match the exact branch shown in the relevant notebook section

--- a/skills/dynamo-preprocess/references/source-grounding.md
+++ b/skills/dynamo-preprocess/references/source-grounding.md
@@ -1,0 +1,124 @@
+# Source Grounding
+
+This skill was not written from notebook prose alone. The concrete interface claims below were checked against live source and runtime inspection.
+
+## Inspection Notes
+
+Interface inspection and smoke checks were performed in a local Python runtime compatible with this repository's dependencies.
+
+## Primary Source Files
+
+Code inspected in:
+
+- `dynamo/preprocessing/Preprocessor.py`
+
+Notebook inspected in:
+
+- `docs/tutorials/notebooks/100_tutorial_preprocess.ipynb`
+
+## Inspected Signatures
+
+### `Preprocessor.__init__`
+
+Observed signature summary:
+
+- exposes overridable callables and kwargs dictionaries for filtering, normalization, feature selection, PCA, gene list forcing, sctransform, regress-out, and cell-cycle scoring
+- default constructor behavior is monocle-oriented
+
+Why this matters:
+
+- the notebook only mutates a few kwargs dictionaries
+- the full constructor is much broader, so the skill intentionally documents only the stable notebook-relevant subset
+
+### `Preprocessor.preprocess_adata`
+
+Inspected signature:
+
+```python
+(self, adata, recipe='monocle', tkey=None, experiment_type=None) -> None
+```
+
+Inspected annotation details:
+
+- `recipe` is a `Literal` over:
+  `monocle`, `seurat`, `sctransform`, `pearson_residuals`, `monocle_pearson_residuals`
+- default is `monocle`
+
+Source-level branch scan:
+
+- `if recipe == "monocle"`
+- `elif recipe == "seurat"`
+- `elif recipe == "sctransform"`
+- `elif recipe == "pearson_residuals"`
+- `elif recipe == "monocle_pearson_residuals"`
+
+Interpretation:
+
+- `recipe` is the main capability selector for this workflow even though the notebook only demonstrates four branches explicitly
+
+### Recipe configuration entrypoints
+
+Inspected signatures:
+
+```python
+config_monocle_recipe(self, adata, n_top_genes=2000) -> None
+config_seurat_recipe(self, adata) -> None
+config_sctransform_recipe(self, adata) -> None
+config_pearson_residuals_recipe(self, adata) -> None
+config_monocle_pearson_residuals_recipe(self, adata) -> None
+```
+
+First-line docstrings observed:
+
+- monocle: automatically configure for monocle recipe
+- seurat: automatically configure for seurat style recipe
+- sctransform: automatically configure for sctransform style recipe
+- pearson residuals: automatically configure for Pearson residuals style recipe
+- monocle + Pearson residuals: automatically configure for the hybrid recipe
+
+## Source-Derived Behavior Notes
+
+### `monocle`
+
+Observed source-specific details:
+
+- computes size factors before normalization
+- runs `log1p`
+- computes PCA
+- also computes new-to-total ratio and cell-cycle score
+
+### `seurat`
+
+Observed source-specific details:
+
+- starts from monocle config
+- swaps gene selection to `select_genes_by_seurat_recipe`
+- uses `algorithm='seurat_dispersion'`
+
+### `sctransform`
+
+Observed source-specific details:
+
+- subsets genes first for efficiency
+- warns that this recipe wrapper imposes that preliminary step
+- expects `KDEpy` at runtime
+
+### `pearson_residuals`
+
+Observed source-specific details:
+
+- disables standard outlier filtering functions
+- uses `normalize_layers_pearson_residuals`
+- treats `adata.X` as the normalization target
+
+### `monocle_pearson_residuals`
+
+Observed source-specific details:
+
+- exists in live source even though the notebook does not make it a main section
+- combines Pearson-residual feature selection and PCA with monocle-style normalization for downstream velocity-safe layers
+
+## Human Review Notes
+
+- The helper script originally emphasized `method` / `backend` / `mode` branch names. For this workflow, `recipe` is the critical branch parameter and was reviewed explicitly from source.
+- The generated skill therefore documents `recipe` as a first-class branch selector instead of inheriting only the notebook's demonstrated path.

--- a/skills/dynamo-preprocess/references/source-notebook-map.md
+++ b/skills/dynamo-preprocess/references/source-notebook-map.md
@@ -1,0 +1,130 @@
+# Source Notebook Map
+
+Source notebook:
+`docs/tutorials/notebooks/100_tutorial_preprocess.ipynb`
+
+Use this file to trace which notebook sections were preserved, condensed, or intentionally dropped.
+
+## Notebook Sections To Skill Responsibilities
+
+### 1. Tutorial overview and glossary
+
+Notebook purpose:
+
+- introduce the `Preprocessor` workflow
+- explain preprocessing-generated keys
+- position the current class API relative to older recipe helpers
+
+Preserved in the skill:
+
+- `SKILL.md` Goal
+- `SKILL.md` Validation
+- `references/compatibility.md`
+
+Important notebook keys carried forward:
+
+- `obs["pass_basic_filter"]`
+- `var["pass_basic_filter"]`
+- `var["use_for_pca"]`
+- `obsm["X_pca"]`
+- recipe-dependent normalized layers such as `X_spliced` and `X_unspliced`
+
+### 2. Wrapper-based recipe usage
+
+Notebook cells show:
+
+- loading `dyn.sample_data.zebrafish()`
+- importing `Preprocessor`
+- calling `preprocess_adata(..., recipe=...)`
+- running PCA-based UMAP afterward
+
+Preserved in the skill:
+
+- `SKILL.md` Quick Workflow
+- `SKILL.md` Minimal Execution Patterns
+- `references/recipe-selection.md`
+
+### 3. Recipe comparisons
+
+Notebook explicitly demonstrates:
+
+- `monocle`
+- `pearson_residuals`
+- `sctransform`
+- `seurat`
+
+Additional source-grounded branch added beyond the notebook:
+
+- `monocle_pearson_residuals`
+
+Reason:
+
+- current source dispatches this branch in `Preprocessor.preprocess_adata(...)`
+- omitting it would make the generated skill incomplete
+
+### 4. Customizing recipe kwargs
+
+Notebook demonstrates mutating:
+
+- `filter_cells_by_outliers_kwargs`
+- `filter_genes_by_outliers_kwargs`
+- `select_genes_kwargs`
+
+Preserved in the skill:
+
+- `SKILL.md` Minimal Execution Patterns
+
+Preserved rule:
+
+- configure a recipe first
+- mutate kwargs second
+- run the matching recipe-specific method third
+
+### 5. Running each step directly
+
+Notebook demonstrates:
+
+- `standardize_adata`
+- `filter_cells_by_outliers`
+- `filter_genes_by_outliers`
+- `normalize_by_cells`
+- `select_genes`
+- `norm_method`
+- `pca`
+- `dyn.tl.reduceDimension(...)`
+
+Preserved in the skill:
+
+- `SKILL.md` Minimal Execution Patterns
+- `references/recipe-selection.md`
+
+Preserved rule:
+
+- use the stepwise path for custom pipelines and debugging
+- use the wrapper for the normal case
+
+## Source-Grounded Additions Beyond The Notebook
+
+These details were added from live source and interface inspection, not just from notebook cells:
+
+- the exact `recipe` signature and default on `Preprocessor.preprocess_adata(...)`
+- the extra source-level `recipe` branch `monocle_pearson_residuals`
+- the constructor signature showing extensive callable and kwargs injection points
+- `config_*_recipe(...)` signatures and their role as configuration entrypoints
+
+## What Was Intentionally Not Carried Over
+
+- plotting style setup
+- long pedagogical prose
+- repeated UMAP cells whose only purpose is visualization parity
+- full output logs and rendered figures
+- every constructor kwarg from `Preprocessor.__init__`, because most are not needed for the notebook-derived stable job
+
+## When To Reopen The Notebook
+
+Reopen the notebook only when:
+
+- the user wants figure parity or cell-by-cell reproduction
+- the user asks for one of the exact kwargs blocks not preserved in the skill
+- the source code and notebook appear to disagree
+- a future notebook revision adds or removes preprocessing branches

--- a/skills/dynamo-pseudotime-velocity/SKILL.md
+++ b/skills/dynamo-pseudotime-velocity/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: dynamo-pseudotime-velocity
+description: Convert pseudotime into reusable `dynamo` RNA velocity outputs on an `AnnData` object, then optionally continue into vector field, topology / potential, fate, and animation without relying on measured spliced/unspliced kinetics. Use when adapting the `201_dynamo_beyondvelo.ipynb` tutorial, working from pseudotime plus a neighbor graph and embedding, or choosing between `pseudotime_velocity` method branches such as `hodge`, `gradient`, and `naive`.
+---
+
+# Dynamo Pseudotime Velocity
+
+## Goal
+
+Turn pseudotime plus a valid neighbor graph into low-dimensional and gene-wise velocity with the current `dynamo` API, then optionally branch into vector-field reconstruction, topology / potential analysis, fate prediction, and presentation-only animation without treating the bone marrow notebook as the workflow identity.
+
+## Quick Workflow
+
+1. Inspect the user's `AnnData` for a pseudotime column, a usable embedding, and whether preprocessing still needs to be run.
+2. Preprocess with `Preprocessor.preprocess_adata(..., recipe='monocle')` unless the user explicitly wants another `recipe`.
+3. Materialize the low-dimensional basis and neighbor graph you will actually use. Do not assume `reduceDimension(...)` already left `obsp['distances']` behind.
+4. Create a sparse-backed `M_s` layer, then run `dyn.tl.pseudotime_velocity(...)` with the right `method` and `dynamics_info` choice.
+5. Add `dyn.vf.VectorField(...)` only when the user needs topology, potential, curl / divergence, or downstream fate prediction.
+6. Treat `topography`, `StreamFuncAnim`, and `animate_streamplot` as optional presentation steps after the analytical outputs already exist.
+
+## Interface Summary
+
+- `Preprocessor.preprocess_adata(adata, recipe='monocle', tkey=None, experiment_type=None)` is the preprocessing wrapper.
+- `dyn.tl.reduceDimension(..., reduction_method='umap')` is the default low-dimensional embedding path, but current source also exposes `trimap`, `diffusion_map`, `tsne`, `psl`, and `sude`.
+- `dyn.tl.pseudotime_velocity(..., pseudotime='pseudotime', basis='umap', adj_key='distances', ekey='M_s', method='hodge', dynamics_info=False, unspliced_RNA=False)` is the core pseudotime-to-velocity entrypoint.
+- `dyn.vf.VectorField(..., basis='umap', method='SparseVFC', pot_curl_div=False, **kwargs)` reconstructs the low-dimensional vector field.
+- `dyn.pd.fate(..., direction='both', average=False, sampling='arc_length', inverse_transform=False)` predicts trajectories from chosen initial cells after vector-field reconstruction.
+- `dyn.pl.topography(...)`, `dyn.mv.StreamFuncAnim(...)`, `dyn.pl.compute_velocity_on_grid(...)`, and `dyn.pl.animate_streamplot(...)` are optional notebook-style visualization / animation entrypoints.
+
+Read [source-grounding.md](./references/source-grounding.md) before documenting any narrower parameter behavior than the live source currently supports.
+
+## Branch Selection
+
+- Use the fresh-embedding branch by default: preprocess, run `reduceDimension(...)`, then explicitly run `dyn.tl.neighbors(...)` if `obsp['distances']` is missing.
+- Use the existing-embedding parity branch only when the user already has a trusted 2D embedding such as `X_tsne` and wants notebook-like plotting parity more than a fresh UMAP.
+- Use `method='hodge'` for the normal pseudotime-to-velocity path. It is the default and was empirically checked through vector field, potential, and fate.
+- Use `method='gradient'` when the user explicitly wants the alternate graph-gradient construction. This branch was also empirically checked and still populates the same core velocity outputs.
+- Use `method='naive'` only when the user explicitly asks for that older branch or you are debugging differences between graph-construction strategies.
+- Use `dynamics_info=True` when downstream tools or checks need `adata.uns['dynamics']`; notebook parity leaves it at the default `False`, but the reusable skill should prefer the more complete branch when compatibility matters.
+- Use `unspliced_RNA=True` only when the user explicitly wants the pseudo-unspliced output stored under `add_ukey` such as `M_u_pseudo`.
+- Use `VectorField(..., method='SparseVFC')` by default. Switch to `method='dynode'` only when the environment has `dynode` and the user explicitly wants that branch.
+- Use `pd.fate(..., direction='forward', average=False, inverse_transform=False)` for notebook-like future-state prediction from progenitor cells. Keep `sampling='arc_length'` unless the user explicitly wants another path.
+
+Read [branch-selection.md](./references/branch-selection.md) before choosing non-default `recipe`, `reduction_method`, `method`, `direction`, or `sampling` branches.
+
+## Input Contract
+
+- Expect an `AnnData` with a pseudotime column such as `adata.obs['palantir_pseudotime']`.
+- Expect either a valid embedding already stored under the basis-specific key such as `adata.obsm['X_umap']`, or enough information to compute one.
+- Expect a materialized adjacency matrix in `.obsp` under the chosen `adj_key`. The default is `distances`.
+- Expect the expression layer passed as `ekey` to support `.toarray()`. If you alias from dense `adata.X`, wrap it with `scipy.sparse.csr_matrix(...)` first.
+- Treat notebook-specific columns such as `clusters`, `palantir_pseudotime`, and `X_tsne` as worked-example inputs, not universal defaults.
+
+## Minimal Execution Patterns
+
+For the default reusable path:
+
+```python
+import dynamo as dyn
+from scipy import sparse
+
+adata = dyn.sample_data.bone_marrow()
+adata.obs_names_make_unique()
+
+pre = dyn.pp.Preprocessor(cell_cycle_score_enable=False)
+pre.preprocess_adata(adata, recipe="monocle")
+
+dyn.tl.reduceDimension(adata)
+if "distances" not in adata.obsp:
+    dyn.tl.neighbors(adata, basis="pca")
+
+adata.layers["M_s"] = adata.X.copy() if sparse.issparse(adata.X) else sparse.csr_matrix(adata.X)
+
+dyn.tl.pseudotime_velocity(
+    adata,
+    pseudotime="palantir_pseudotime",
+    basis="umap",
+    method="hodge",
+    dynamics_info=True,
+)
+```
+
+For notebook-style embedding reuse when an existing 2D embedding already exists:
+
+```python
+if "X_tsne" in adata.obsm and "X_umap" not in adata.obsm:
+    adata.obsm["X_umap"] = adata.obsm["X_tsne"].copy()
+
+if "distances" not in adata.obsp:
+    dyn.tl.neighbors(adata, basis="pca")
+```
+
+For the optional vector-field, topology, and fate branch:
+
+```python
+dyn.vf.VectorField(adata, basis="umap", M=100, pot_curl_div=True, cores=1)
+
+progenitor = adata.obs_names[adata.obs[group_key].isin(progenitor_labels)][:20]
+
+dyn.pd.fate(
+    adata,
+    basis="umap",
+    init_cells=progenitor,
+    interpolation_num=30,
+    direction="forward",
+    inverse_transform=False,
+    average=False,
+    cores=1,
+)
+```
+
+For the non-default `gradient` branch:
+
+```python
+dyn.tl.pseudotime_velocity(
+    adata,
+    pseudotime="palantir_pseudotime",
+    basis="umap",
+    method="gradient",
+    dynamics_info=False,
+)
+```
+
+## Validation
+
+After preprocessing, check these items:
+
+- `adata.obsm["X_pca"]` exists.
+- `adata.var["use_for_pca"]` exists.
+- `adata.uns["pp"]` exists.
+
+Before `pseudotime_velocity(...)`, check these items:
+
+- the chosen pseudotime key exists in `adata.obs`
+- `adata.obsm["X_umap"]` exists for the default `basis='umap'` path
+- `adata.obsp["distances"]` exists if `adj_key='distances'`
+- `adata.layers["M_s"]` exists and is sparse-backed or otherwise `.toarray()`-compatible
+
+After `pseudotime_velocity(...)`, check these items:
+
+- `adata.obsm["velocity_umap"]` exists
+- `adata.layers["velocity_S"]` exists
+- `adata.obsp["pseudotime_transition_matrix"]` exists
+- `adata.var["use_for_dynamics"]` and `adata.var["use_for_transition"]` exist
+- `adata.uns["dynamics"]` exists only if `dynamics_info=True`
+
+After `VectorField(..., basis='umap', pot_curl_div=True)`, check these items:
+
+- `adata.uns["VecFld_umap"]` exists
+- `adata.obs["obs_vf_angle_umap"]` exists
+- `adata.obs["umap_ddhodge_potential"]` exists
+- `adata.obs["curl_umap"]` and `adata.obs["divergence_umap"]` exist
+
+After `pd.fate(..., basis='umap')`, check these items:
+
+- `adata.uns["fate_umap"]` exists
+- `adata.uns["fate_umap"]["t"]` exists
+- `adata.uns["fate_umap"]["prediction"]` exists
+
+## Constraints
+
+- Do not assume `dyn.tl.reduceDimension(...)` alone leaves a usable `obsp['distances']` matrix in this runtime. Check and materialize it explicitly with `dyn.tl.neighbors(...)` when needed.
+- Do not treat `adata.obsm['X_umap'] = adata.obsm['X_tsne']` as the default workflow. It is a demo-specific parity shortcut from the notebook.
+- Do not set `adata.layers["M_s"] = adata.X` blindly when `adata.X` is dense. Current source calls `.toarray()` on `ekey`.
+- Do not imply that `M=1000` is a public `VectorField` signature parameter. Current source forwards it through `**kwargs`.
+- Do not let animation setup block the analytical path. `StreamFuncAnim` and GIF export may require external tooling such as `imagemagick`.
+
+## Resource Map
+
+- Read [branch-selection.md](./references/branch-selection.md) for decision rules across `recipe`, `reduction_method`, `method`, and `fate` branches.
+- Read [visualization-and-animation.md](./references/visualization-and-animation.md) when the user explicitly wants notebook-style plots, topology figures, or animations.
+- Read [source-grounding.md](./references/source-grounding.md) for inspected signatures, source-level branch evidence, and empirical execution notes.
+- Read [source-notebook-map.md](./references/source-notebook-map.md) to trace `201_dynamo_beyondvelo.ipynb` into the reusable skill layout.
+- Read [compatibility.md](./references/compatibility.md) when notebook prose and current source behavior diverge.

--- a/skills/dynamo-pseudotime-velocity/assets/acceptance.json
+++ b/skills/dynamo-pseudotime-velocity/assets/acceptance.json
@@ -1,0 +1,72 @@
+{
+  "version": 1,
+  "skill": "dynamo-pseudotime-velocity",
+  "sample_requests": [
+    "Convert pseudotime into dynamo RNA velocity and continue into vector field and fate without relying on measured spliced or unspliced kinetics",
+    "Adapt 201_dynamo_beyondvelo.ipynb into a reusable AnnData workflow with the current pseudotime_velocity API"
+  ],
+  "required_description_terms": [
+    "dynamo",
+    "pseudotime",
+    "velocity",
+    "vector field",
+    "anndata",
+    "tutorial"
+  ],
+  "required_sections": [
+    "## Goal",
+    "## Quick Workflow",
+    "## Interface Summary",
+    "## Branch Selection",
+    "## Minimal Execution Patterns",
+    "## Validation",
+    "## Resource Map"
+  ],
+  "required_body_terms": [
+    "pseudotime_velocity",
+    "distances",
+    "M_s",
+    "velocity_umap",
+    "pseudotime_transition_matrix",
+    "umap_ddhodge_potential",
+    "fate_umap",
+    "gradient"
+  ],
+  "required_paths": [
+    "references/branch-selection.md",
+    "references/visualization-and-animation.md",
+    "references/source-notebook-map.md",
+    "references/source-grounding.md",
+    "references/compatibility.md"
+  ],
+  "smoke_commands": [
+    {
+      "name": "hodge-core-vectorfield-fate",
+      "conda_env": "omictest",
+      "env": {
+        "PYTHONPATH": ".",
+        "MPLCONFIGDIR": "/tmp/mpl",
+        "NUMBA_CACHE_DIR": "/tmp/numba"
+      },
+      "command": "${PYTHON} -c \"import anndata as ad, dynamo as dyn; from scipy import sparse; adata=dyn.sample_data.bone_marrow(); clusters=['HSC_1','HSC_2','Ery_1','Mono_1']; parts=[adata[adata.obs['clusters']==c][:40].copy() for c in clusters]; adata=ad.concat(parts, merge='same', label='subset_batch', keys=clusters, index_unique='-'); adata.obs_names_make_unique(); pre=dyn.pp.Preprocessor(cell_cycle_score_enable=False); pre.preprocess_adata(adata, recipe='monocle'); dyn.tl.reduceDimension(adata); dyn.tl.neighbors(adata, basis='pca'); adata.layers['M_s']=adata.X.copy() if sparse.issparse(adata.X) else sparse.csr_matrix(adata.X); dyn.tl.pseudotime_velocity(adata, pseudotime='palantir_pseudotime', dynamics_info=True); dyn.vf.VectorField(adata, basis='umap', M=100, pot_curl_div=True, cores=1); progenitor=adata.obs_names[adata.obs['clusters'].isin(['HSC_1'])][:15]; dyn.pd.fate(adata, basis='umap', init_cells=progenitor, interpolation_num=20, direction='forward', inverse_transform=False, average=False, cores=1); print('velocity_umap' in adata.obsm, 'pseudotime_transition_matrix' in adata.obsp, 'VecFld_umap' in adata.uns, 'umap_ddhodge_potential' in adata.obs, 'curl_umap' in adata.obs, 'fate_umap' in adata.uns)\"",
+      "timeout_seconds": 300,
+      "expect_stdout_contains": [
+        "True True True True True True"
+      ]
+    },
+    {
+      "name": "gradient-branch",
+      "conda_env": "omictest",
+      "env": {
+        "PYTHONPATH": ".",
+        "MPLCONFIGDIR": "/tmp/mpl",
+        "NUMBA_CACHE_DIR": "/tmp/numba"
+      },
+      "command": "${PYTHON} -c \"import anndata as ad, dynamo as dyn; from scipy import sparse; adata=dyn.sample_data.bone_marrow(); clusters=['HSC_1','HSC_2','Ery_1']; parts=[adata[adata.obs['clusters']==c][:30].copy() for c in clusters]; adata=ad.concat(parts, merge='same', label='subset_batch', keys=clusters, index_unique='-'); adata.obs_names_make_unique(); pre=dyn.pp.Preprocessor(cell_cycle_score_enable=False); pre.preprocess_adata(adata, recipe='monocle'); dyn.tl.reduceDimension(adata); dyn.tl.neighbors(adata, basis='pca'); adata.layers['M_s']=adata.X.copy() if sparse.issparse(adata.X) else sparse.csr_matrix(adata.X); dyn.tl.pseudotime_velocity(adata, pseudotime='palantir_pseudotime', method='gradient', dynamics_info=False); print('velocity_umap' in adata.obsm, 'velocity_S' in adata.layers, 'pseudotime_transition_matrix' in adata.obsp, 'dynamics' in adata.uns)\"",
+      "timeout_seconds": 240,
+      "expect_stdout_contains": [
+        "True True True False"
+      ]
+    }
+  ]
+}

--- a/skills/dynamo-pseudotime-velocity/references/branch-selection.md
+++ b/skills/dynamo-pseudotime-velocity/references/branch-selection.md
@@ -1,0 +1,134 @@
+# Branch Selection
+
+This notebook mixes preprocessing, embedding reuse, pseudotime-to-velocity conversion, vector-field analysis, topology, fate, and animation. Use this reference to keep those stages separate instead of replaying every cell literally.
+
+## Default Job
+
+If the user asks to run a pseudotime-derived `dynamo` velocity workflow without measured spliced / unspliced kinetics:
+
+1. preprocess with `recipe='monocle'`
+2. compute or validate a 2D basis such as UMAP
+3. explicitly materialize `obsp['distances']` if it is missing
+4. create `M_s`
+5. run `dyn.tl.pseudotime_velocity(..., method='hodge', dynamics_info=True)`
+6. add `VectorField` and `fate` only if the goal needs them
+
+## Stage 1: Preprocessing
+
+Current source branches for `Preprocessor.preprocess_adata(...)`:
+
+- `monocle`
+- `seurat`
+- `sctransform`
+- `pearson_residuals`
+- `monocle_pearson_residuals`
+
+Recommendation for this workflow family:
+
+- use `monocle` by default
+
+Reason:
+
+- the notebook reuses the preprocessing family from the earlier dynamo tutorial
+- downstream embedding, neighbor-graph, and velocity handoff work cleanly on the monocle path
+
+## Stage 2: Embedding And Neighbor Graph
+
+Relevant branch-heavy parameter on `dyn.tl.reduceDimension(...)`:
+
+- `reduction_method`: `trimap`, `diffusion_map`, `tsne`, `umap`, `psl`, `sude`
+
+Recommendation for this workflow family:
+
+- use `reduction_method='umap'` for the default analytical path
+
+When to switch:
+
+- use an existing 2D embedding only when the user explicitly wants notebook-style parity with precomputed coordinates
+- use `tsne` or another branch only when the user specifically asks for that embedding and understands downstream plots will key off the matching `basis`
+
+Important runtime rule:
+
+- after `reduceDimension(...)`, check `adata.obsp`
+- if `distances` is missing, run `dyn.tl.neighbors(adata, basis='pca')` before `pseudotime_velocity(...)`
+
+## Stage 3: Pseudotime To Velocity
+
+Relevant branch-heavy parameters on `dyn.tl.pseudotime_velocity(...)`:
+
+- `method`: `hodge`, `gradient`, `naive`
+- `dynamics_info`: `False` / `True`
+- `unspliced_RNA`: `False` / `True`
+
+Recommendation for this workflow family:
+
+- use `method='hodge'`
+- use `dynamics_info=True` for the reusable skill path
+- keep `unspliced_RNA=False` unless the user explicitly wants pseudo-unspliced outputs
+
+When to switch:
+
+- use `method='gradient'` when the user explicitly wants the alternate graph-gradient transition construction
+- use `method='naive'` only for explicit branch comparison or legacy parity debugging
+- use `dynamics_info=False` only when notebook parity matters more than downstream compatibility metadata
+
+Important storage rules:
+
+- `ekey` defaults to `M_s`
+- `vkey` defaults to `velocity_S`
+- transition output is stored under `adata.obsp['pseudotime_transition_matrix']`
+- `unspliced_RNA=True` stores the pseudo-unspliced result under `add_ukey`, default `M_u_pseudo`
+
+## Stage 4: Vector Field
+
+Relevant branch-heavy parameters on `dyn.vf.VectorField(...)`:
+
+- `method`: `SparseVFC`, `dynode`
+- `pot_curl_div`: `False` / `True`
+
+Recommendation for this workflow family:
+
+- use `basis='umap'`, `method='SparseVFC'`
+
+When to switch:
+
+- use `pot_curl_div=True` when the user wants potential, curl, divergence, or `topography`
+- use `method='dynode'` only when `dynode` is installed and explicitly requested
+
+About `M`:
+
+- the notebook uses `M=1000`
+- current source forwards `M` through `**kwargs`, not the public signature
+
+## Stage 5: Fate Prediction
+
+Relevant branch-heavy parameters on `dyn.pd.fate(...)`:
+
+- `direction`: `forward`, `backward`, `both`
+- `average`: `False`, `True`, `origin`, `trajectory`
+- `sampling`: `arc_length`, `logspace`, `uniform_indices`
+- `inverse_transform`: `False` / `True`
+
+Recommendation for this workflow family:
+
+- use `basis='umap'`
+- use `direction='forward'`
+- use `average=False`
+- use `sampling='arc_length'`
+- use `inverse_transform=False`
+
+When to switch:
+
+- use `direction='both'` only when the user wants both ancestry and descendants from the same start states
+- use `average='trajectory'` only when the user explicitly wants averaged trajectories over multiple initial cells
+- use `sampling='uniform_indices'` only when the user accepts that multiprocessing is disabled
+
+## Decision Rule
+
+If the user asks for:
+
+- "the notebook result" -> run the default job, but treat bone marrow labels and the `X_tsne` reuse cell as worked-example branches
+- "just pseudotime-derived velocity" -> stop after `pseudotime_velocity(...)`
+- "potential" or "fixed points" -> add `VectorField(..., pot_curl_div=True)` and `topography`
+- "fate" -> run `VectorField` first, then `pd.fate(...)`
+- "animation" -> run `fate` first, then the visualization / animation entrypoints

--- a/skills/dynamo-pseudotime-velocity/references/compatibility.md
+++ b/skills/dynamo-pseudotime-velocity/references/compatibility.md
@@ -1,0 +1,36 @@
+# Compatibility
+
+Use this reference when notebook wording and current source behavior may not be identical.
+
+## Current API Preference
+
+Prefer:
+
+- `dynamo.preprocessing.Preprocessor`
+- `dyn.tl.pseudotime_velocity`
+- `dyn.vf.VectorField`
+- `dyn.pd.fate`
+
+Do not default to older helper paths unless the user explicitly asks for legacy behavior.
+
+## Source Vs Notebook
+
+- The notebook copies `X_tsne` into `X_umap` for demonstration. The generated skill keeps that as an optional parity branch, not the default workflow.
+- Current `pseudotime_velocity(...)` source exposes three real `method` branches: `hodge`, `gradient`, `naive`. The notebook shows only the default path.
+- In this runtime, `reduceDimension(...)` can leave `uns['neighbors']` populated while `obsp['distances']` is still missing. The generated skill adds an explicit `neighbors(...)` verification step.
+- Current `pseudotime_velocity(...)` reads `adata.layers[ekey].toarray()`. If you alias from dense `adata.X`, convert it to `csr_matrix` first.
+- `unspliced_RNA=True` stores output under `add_ukey`, default `M_u_pseudo`; it does not create a canonical `unspliced` layer automatically.
+
+## Runtime Constraints
+
+- Importing `dynamo` in this workspace is most stable in a repository-compatible Python environment with writable matplotlib and numba cache directories.
+- `dyn.sample_data.bone_marrow()` may require a network download if the dataset is not cached.
+- GIF export and some animation save paths may require external tooling such as `imagemagick`.
+
+## Conservative Rule
+
+If notebook text and current source disagree:
+
+1. trust the current source for executable behavior
+2. mention the drift explicitly
+3. reopen the notebook only if figure parity or historical reproduction is the real goal

--- a/skills/dynamo-pseudotime-velocity/references/source-grounding.md
+++ b/skills/dynamo-pseudotime-velocity/references/source-grounding.md
@@ -1,0 +1,225 @@
+# Source Grounding
+
+This skill was generated from live code inspection and empirical execution on the bone marrow worked example, not from notebook prose alone.
+
+## Inspection Notes
+
+Source inspection and empirical checks were performed in a local Python runtime compatible with this repository's dependencies.
+
+## Primary Source Files
+
+Notebook inspected:
+
+- `docs/tutorials/notebooks/201_dynamo_beyondvelo.ipynb`
+
+Code inspected:
+
+- `dynamo/preprocessing/Preprocessor.py`
+- `dynamo/tools/dimension_reduction.py`
+- `dynamo/tools/utils_reduceDimension.py`
+- `dynamo/tools/connectivity.py`
+- `dynamo/tools/pseudotime_velocity.py`
+- `dynamo/vectorfield/VectorField.py`
+- `dynamo/prediction/fate.py`
+- `dynamo/plot/topography.py`
+- `dynamo/movie/fate.py`
+- `dynamo/plot/animation_lines.py`
+
+## Inspected Interfaces
+
+### `Preprocessor.preprocess_adata`
+
+Observed signature:
+
+```python
+(self, adata, recipe='monocle', tkey=None, experiment_type=None) -> None
+```
+
+Observed `recipe` branches in current source:
+
+- `monocle`
+- `seurat`
+- `sctransform`
+- `pearson_residuals`
+- `monocle_pearson_residuals`
+
+### `dyn.tl.reduceDimension`
+
+Observed signature includes:
+
+```python
+(..., basis='pca', n_pca_components=30, reduction_method='umap', ...) -> Optional[AnnData]
+```
+
+Observed `reduction_method` branches in current source:
+
+- `trimap`
+- `diffusion_map`
+- `tsne`
+- `umap`
+- `psl`
+- `sude`
+
+Important source detail:
+
+- `reduceDimension(...)` may populate `uns['neighbors']` itself
+- because of that, its fallback `neighbors(...)` call may be skipped even when `obsp['distances']` is still absent
+
+### `dyn.tl.pseudotime_velocity`
+
+Observed signature:
+
+```python
+(adata, pseudotime='pseudotime', basis='umap', adj_key='distances', ekey='M_s', vkey='velocity_S', add_tkey='pseudotime_transition_matrix', add_ukey='M_u_pseudo', method='hodge', dynamics_info=False, unspliced_RNA=False) -> None
+```
+
+Observed `method` branches:
+
+- `hodge`
+- `gradient`
+- `naive`
+
+Important source details:
+
+- `adata.obsp[adj_key]` must exist before the call
+- `adata.layers[ekey].toarray()` is called internally, so a dense `numpy.ndarray` layer alias will fail
+- `dynamics_info=True` adds `adata.uns['dynamics']` with `experiment_type='conventional'`, `has_splicing=True`, `use_smoothed=True`, and `est_method='conventional'`
+- `unspliced_RNA=True` stores pseudo-unspliced output under `add_ukey`, default `M_u_pseudo`, and adds `pseudotime_vel_params`
+
+### `dyn.vf.VectorField`
+
+Observed signature:
+
+```python
+(adata, basis=None, layer=None, ..., method='SparseVFC', pot_curl_div=False, **kwargs)
+```
+
+Observed `method` branches:
+
+- `SparseVFC`
+- `dynode`
+
+Important source details:
+
+- notebook argument `M=1000` is not part of the public signature
+- current source forwards `M` through `**kwargs`
+- `pot_curl_div=True` runs `ddhodge(...)`, then curl for 2D bases, then divergence
+
+### `dyn.pd.fate`
+
+Observed signature includes these branch-heavy parameters:
+
+- `direction`: `forward`, `backward`, `both`
+- `average`: `False`, `True`, `origin`, `trajectory`
+- `sampling`: `arc_length`, `logspace`, `uniform_indices`
+- `inverse_transform`: `False`, `True`
+
+Observed runtime storage rule:
+
+- `basis='umap'` stores fate outputs under `adata.uns['fate_umap']`
+
+### Visualization / Animation Entry Points
+
+Observed signatures:
+
+- `dyn.pl.topography(...)`
+- `dyn.mv.StreamFuncAnim(...)`
+- `dyn.pl.compute_velocity_on_grid(...)`
+- `dyn.pl.animate_streamplot(...)`
+
+Important preconditions:
+
+- `topography(...)` is most useful after `VectorField(..., pot_curl_div=True)`
+- `StreamFuncAnim(...)` expects prior `fate(...)` output
+- `animate_streamplot(...)` operates on precomputed `X_grid`, `V_grid`
+
+## Empirical Checks Run
+
+### Sample Data Load
+
+Observed on the current bone marrow worked example:
+
+- shape is `5780 x 27876`
+- `.obs` includes `clusters`, `palantir_pseudotime`, `palantir_diff_potential`
+- `.obsm` includes `X_tsne`
+- `.layers` includes `spliced`, `unspliced`
+- `adata.X` is a `csr_matrix`
+- observation names are already unique
+
+Worked-example note:
+
+- these metadata names are useful for reproducing `201_dynamo_beyondvelo.ipynb`
+- they are not part of the generic input contract for the skill
+
+### Neighbor Graph Materialization Check
+
+Checked on a `160`-cell subset across `HSC_1`, `HSC_2`, `Ery_1`, and `Mono_1`:
+
+1. `preprocess_adata(..., recipe='monocle')`
+2. `reduceDimension(...)`
+
+Observed result:
+
+- `adata.uns['neighbors']` existed
+- `adata.obsp` was still empty
+- explicit `dyn.tl.neighbors(adata, basis='pca')` then created `obsp['distances']` and `obsp['connectivities']`
+
+### Core Pseudotime Path
+
+Checked on a `160`-cell subset after the neighbor-graph fix:
+
+1. `preprocess_adata(..., recipe='monocle')`
+2. `reduceDimension(...)`
+3. `neighbors(adata, basis='pca')`
+4. `adata.layers['M_s'] = csr_matrix-backed expression`
+5. `pseudotime_velocity(..., pseudotime='palantir_pseudotime', method='hodge', dynamics_info=True)`
+
+Observed outputs:
+
+- `X_pca`
+- `X_umap`
+- `velocity_umap`
+- `velocity_S`
+- `pseudotime_transition_matrix`
+- `use_for_dynamics`
+- `use_for_transition`
+- `dynamics`
+
+### Vector Field, Potential, And Fate Branch
+
+Checked on the same `160`-cell subset after the core path:
+
+1. `VectorField(..., basis='umap', M=100, pot_curl_div=True, cores=1)`
+2. `pd.fate(..., basis='umap', direction='forward', average=False, inverse_transform=False, cores=1)`
+
+Observed outputs:
+
+- `adata.uns['VecFld_umap']`
+- `adata.obs['obs_vf_angle_umap']`
+- `adata.obs['umap_ddhodge_potential']`
+- `adata.obs['curl_umap']`
+- `adata.obs['divergence_umap']`
+- `adata.uns['fate_umap']`
+- `adata.uns['fate_umap']` includes `t` and `prediction`
+
+### Alternate `gradient` Branch
+
+Checked on a `90`-cell subset across `HSC_1`, `HSC_2`, and `Ery_1`:
+
+1. `preprocess_adata(..., recipe='monocle')`
+2. `reduceDimension(...)`
+3. `neighbors(adata, basis='pca')`
+4. `pseudotime_velocity(..., method='gradient', dynamics_info=False)`
+
+Observed outputs:
+
+- `velocity_umap`
+- `velocity_S`
+- `pseudotime_transition_matrix`
+- `dynamics` remained absent, matching `dynamics_info=False`
+
+## Human Review Notes
+
+- The stable reusable job is pseudotime-to-velocity conversion, not "run the bone marrow notebook."
+- The strongest compatibility trap here is the missing `obsp['distances']` after `reduceDimension(...)`, not the pseudotime method call itself.
+- The second strongest trap is that `ekey` must be sparse-backed or `.toarray()`-compatible.

--- a/skills/dynamo-pseudotime-velocity/references/source-notebook-map.md
+++ b/skills/dynamo-pseudotime-velocity/references/source-notebook-map.md
@@ -1,0 +1,152 @@
+# Source Notebook Map
+
+Source notebook:
+`docs/tutorials/notebooks/201_dynamo_beyondvelo.ipynb`
+
+Use this file to see how the notebook was converted into a reusable pseudotime-to-velocity skill.
+
+Conversion rule used here:
+
+- the stable skill identity is converting pseudotime into `dynamo` velocity and downstream vector-field outputs
+- bone marrow remains the worked example notebook, not the trigger surface
+
+## Notebook Sections To Skill Responsibilities
+
+### 1. Setup And Sample-Data Loading
+
+Notebook role:
+
+- import `dynamo`
+- set plotting style
+- load `dyn.sample_data.bone_marrow()`
+
+Preserved in the skill:
+
+- `SKILL.md` Quick Workflow
+- `SKILL.md` Input Contract
+- `references/source-grounding.md`
+- `references/compatibility.md`
+
+Intentionally dropped:
+
+- notebook magics
+- presentation styling
+- dependency-version display cells
+
+### 2. Precomputed Embedding Reuse
+
+Notebook role:
+
+- copy `X_tsne` into `X_umap` for demonstration
+
+Preserved in the skill:
+
+- `SKILL.md` Branch Selection
+- `SKILL.md` Minimal Execution Patterns
+
+Downgrade rule:
+
+- this is kept as an optional parity branch, not the default reusable workflow
+
+### 3. Preprocessing
+
+Notebook role:
+
+- reuse the monocle preprocessing path before downstream analysis
+
+Preserved in the skill:
+
+- `SKILL.md` Quick Workflow
+- `references/branch-selection.md`
+
+Source-grounded addition:
+
+- current `Preprocessor` source exposes more `recipe` branches than the notebook uses
+
+### 4. Convert Pseudotime To Velocity
+
+Notebook role:
+
+- create `M_s`
+- run `dyn.tl.pseudotime_velocity(adata, pseudotime='palantir_pseudotime')`
+
+Preserved in the skill:
+
+- `SKILL.md` Interface Summary
+- `SKILL.md` Minimal Execution Patterns
+- `SKILL.md` Validation
+
+Source-grounded additions:
+
+- explicit `method` branches: `hodge`, `gradient`, `naive`
+- explicit `dynamics_info` and `unspliced_RNA` behavior
+- explicit requirement that `adj_key` actually exist in `.obsp`
+
+### 5. Velocity Visualization
+
+Notebook role:
+
+- `streamline_plot`
+- `cell_wise_vectors`
+
+Preserved in the skill:
+
+- `references/visualization-and-animation.md`
+
+### 6. Vector Field, Potential, And Topography
+
+Notebook role:
+
+- `VectorField(..., pot_curl_div=True)`
+- `plot_energy`
+- `topography`
+- `umap(..., color='umap_ddhodge_potential')`
+
+Preserved in the skill:
+
+- `SKILL.md` Branch Selection
+- `SKILL.md` Validation
+- `references/visualization-and-animation.md`
+
+Source-grounded addition:
+
+- `pot_curl_div=True` is the compact executable branch that materializes potential, curl, and divergence outputs together
+
+### 7. Fate And Animation
+
+Notebook role:
+
+- select progenitors
+- run `pd.fate`
+- build `StreamFuncAnim`
+- create animated streamplots
+
+Preserved in the skill:
+
+- `SKILL.md` Minimal Execution Patterns
+- `references/visualization-and-animation.md`
+
+## Source-Grounded Additions Beyond The Notebook
+
+These details were added from live source inspection and empirical execution, not notebook prose alone:
+
+- `reduceDimension(...)` branch coverage for `reduction_method`
+- `pseudotime_velocity(...)` branch coverage for `method`
+- the runtime trap where `reduceDimension(...)` can leave `uns['neighbors']` populated while `obsp['distances']` is still missing
+- the requirement that `M_s` be sparse-backed or otherwise `.toarray()`-compatible
+- the optional `dynamics_info=True` branch for downstream metadata compatibility
+
+## What Was Intentionally Not Carried Over
+
+- long biological interpretation prose
+- notebook-only HTML / JS embedding cells
+- repeated background-color toggles
+- direct file-save examples whose only purpose is presentation parity
+
+## When To Reopen The Notebook
+
+Reopen the notebook only when:
+
+- the user wants exact bone marrow figure parity
+- the user wants the same embedded animation presentation style
+- a future notebook revision changes the demonstrated pseudotime handoff or downstream branch order

--- a/skills/dynamo-pseudotime-velocity/references/visualization-and-animation.md
+++ b/skills/dynamo-pseudotime-velocity/references/visualization-and-animation.md
@@ -1,0 +1,103 @@
+# Visualization And Animation
+
+Use this reference only when the user explicitly wants notebook-style plots, topology visuals, or animations.
+
+## Streamline And Cell-Wise Velocity Plots
+
+Primary entrypoints:
+
+- `dyn.pl.streamline_plot(...)`
+- `dyn.pl.cell_wise_vectors(...)`
+
+Recommended prerequisites:
+
+1. `dyn.tl.pseudotime_velocity(...)`
+2. a matching low-dimensional embedding such as `X_umap`
+
+Notebook-like calls:
+
+```python
+dyn.pl.streamline_plot(
+    adata,
+    color=["clusters"],
+    basis="umap",
+    show_legend="on data",
+)
+
+dyn.pl.cell_wise_vectors(
+    adata,
+    color=["clusters"],
+    basis="umap",
+    show_legend="on data",
+)
+```
+
+## Vector Field Topology
+
+Primary entrypoint:
+
+- `dyn.pl.topography(...)`
+
+Recommended prerequisites:
+
+1. `dyn.tl.pseudotime_velocity(...)`
+2. `dyn.vf.VectorField(..., basis='umap', pot_curl_div=True)`
+
+Notebook-like call:
+
+```python
+dyn.pl.topography(
+    adata,
+    basis="umap",
+    color=["ntr", "clusters"],
+    streamline_color="black",
+    show_legend="on data",
+    frontier=True,
+)
+```
+
+Use `dyn.pl.umap(adata, color='umap_ddhodge_potential')` only after validating that `adata.obs['umap_ddhodge_potential']` exists.
+
+## Fate Animation
+
+Primary entrypoints:
+
+- `dyn.mv.StreamFuncAnim(...)`
+- `dyn.mv.animate_fates(...)`
+
+Required prerequisite:
+
+- `dyn.pd.fate(...)` must already have populated `adata.uns['fate_<basis>']`
+
+Notebook-like path:
+
+```python
+fig, ax = plt.subplots(figsize=(4, 4))
+ax = dyn.pl.topography(adata, color="clusters", ax=ax, save_show_or_return="return")
+
+instance = dyn.mv.StreamFuncAnim(
+    adata=adata,
+    color="clusters",
+    ax=ax,
+)
+```
+
+Important branch note:
+
+- `StreamFuncAnim(..., logspace=False)` samples evenly by default
+- `dyn.mv.animate_fates(..., logspace=True)` is an explicit alternate branch for log-spaced time sampling
+
+## Streamplot GIF Path
+
+Notebook-specific optional path:
+
+1. `X_grid, V_grid = dyn.pl.compute_velocity_on_grid(adata.obsm['X_umap'], adata.obsm['velocity_umap'])`
+2. `dyn.pl.animate_streamplot(X_grid, V_grid, adata, ...)`
+
+This is presentation-heavy and not required for the analytical workflow.
+
+## Constraints
+
+- Do not let animation setup block the main analysis.
+- Keep notebook magics, `font_path='Arial'`, and background-color toggles out of the default workflow unless the user explicitly wants presentation parity.
+- GIF export may require external animation tooling such as `imagemagick`.


### PR DESCRIPTION
This pull request introduces a new skill for running and adapting conventional spliced/unspliced RNA velocity workflows in `dynamo`, with a focus on making the pipeline reusable and source-grounded rather than notebook-specific. It provides a comprehensive skill description, validation criteria, compatibility notes, and acceptance tests, all based on live code inspection and empirical execution rather than just notebook prose. The most important changes are grouped below by theme.

**Skill Implementation and Documentation:**

* Added `skills/dynamo-conventional-rna-velocity/SKILL.md`, a detailed skill description for running and adapting conventional spliced/unspliced RNA velocity workflows in `dynamo`, including interface summary, workflow stages, validation, constraints, and resource mapping. This document emphasizes stage-based execution, source-grounded defaults, and dataset-agnostic usage.

**Testing and Acceptance Criteria:**

* Added `skills/dynamo-conventional-rna-velocity/assets/acceptance.json`, specifying sample requests, required documentation sections and terms, required resource files, and two smoke test commands to validate the skill's core and topology/potential branches in a conda environment.

**Source and Compatibility References:**

* Added `skills/dynamo-conventional-rna-velocity/references/source-grounding.md`, documenting the source inspection process, observed interfaces, empirical checks, and compatibility traps, ensuring the skill reflects actual code and runtime behavior.
* Added `skills/dynamo-conventional-rna-velocity/references/compatibility.md`, outlining compatibility notes between notebook wording and current source behavior, especially regarding data shape, transition matrix storage, and animation tooling.
* Added `skills/dynamo-conventional-rna-velocity/references/source-notebook-map.md`, mapping sections of the original zebrafish tutorial notebook to the new skill structure, and noting what was intentionally omitted or generalized.

**Packaging:**

* Added `meta.yaml` for conda packaging of the `dynamo-release` version 1.5.2, specifying dependencies, test imports, and metadata for distribution.