### PR TITLE
Add `normalized` flag to Preprocessor to skip normalization

### DIFF
--- a/dynamo/preprocessing/Preprocessor.py
+++ b/dynamo/preprocessing/Preprocessor.py
@@ -75,6 +75,7 @@ class Preprocessor:
         regress_out_kwargs: Dict[List[str], Any] = {},
         cell_cycle_score_enable: bool = False,
         cell_cycle_score_kwargs: Dict[str, Any] = {},
+        normalized: bool = False,
     ) -> None:
         """Preprocessor constructor.
 
@@ -134,6 +135,7 @@ class Preprocessor:
         self.regress_out = regress_out_parallel
         self.pca = pca_function
         self.pca_kwargs = pca_kwargs
+        self.skip_normalize = normalized
 
         # self.n_top_genes = n_top_genes
         self.convert_gene_name = convert_gene_name_function
@@ -382,7 +384,9 @@ class Preprocessor:
             adata: an AnnData object.
         """
 
-        if callable(self.normalize_selected_genes):
+        if self.skip_normalize:
+            main_info("Data already normalized. Skipping gene-wise normalization.")
+        elif callable(self.normalize_selected_genes):
             main_debug("normalizing selected genes...")
             self.normalize_selected_genes(adata, **self.normalize_selected_genes_kwargs)
 
@@ -393,7 +397,9 @@ class Preprocessor:
             adata: an AnnData object.
         """
 
-        if callable(self.normalize_by_cells):
+        if self.skip_normalize:
+            main_info("Data already normalized. Skipping cell-wise normalization.")
+        elif callable(self.normalize_by_cells):
             main_debug("applying normalize by cells function...")
             self.normalize_by_cells(adata, **self.normalize_by_cells_function_kwargs)
 
@@ -404,7 +410,9 @@ class Preprocessor:
             adata: an AnnData object.
         """
 
-        if callable(self.norm_method):
+        if self.skip_normalize:
+            main_info("Data already normalized. Skipping normalization.")
+        elif callable(self.norm_method):
             main_debug("applying a normalization method transformation on expression matrix data...")
             self.norm_method(adata, **self.norm_method_kwargs)
 


### PR DESCRIPTION
Reimplements the intent of #601 (closed: stale base) on current master.

## Summary
Adds a `normalized: bool = False` argument to `Preprocessor`. When set to `True`, the three normalization steps — `_normalize_by_cells`, `_normalize_selected_genes`, and the `norm_method` transform — are skipped (each logs an info message), while filtering, gene selection, regression and PCA still run. This lets users feed already-normalized data through the Preprocessor without double-normalizing.

## Usage
```python
preprocessor = dyn.pp.Preprocessor(normalized=True)
preprocessor.preprocess_adata(adata, recipe="monocle")
```

## Validation
Verified on a synthetic AnnData: with `normalized=True`, `adata.X` is left unchanged (raw counts preserved) and all three skip-messages fire.

Closes the goal of #601.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AD7gAdxa3Zt5uiQVDoANa5