### PR TITLE
Make export_kmc robust when `kmc` is absent

### DIFF
--- a/dynamo/data_io.py
+++ b/dynamo/data_io.py
@@ -353,7 +353,11 @@ def export_rank_xlsx(
 
 def export_kmc(adata: AnnData) -> None:
     """Save the parameters of kmc and delete the kmc object from anndata."""
-    kmc = adata.uns["kmc"]
+    kmc = adata.uns.get("kmc", None)
+    if kmc is None:
+        main_info("`kmc` is empty or does not exist in adata.uns; nothing to export.")
+        adata.uns.pop("kmc", None)
+        return
     adata.uns["kmc_params"] = {
         "P": kmc.P,
         "Idx": kmc.Idx,
@@ -364,7 +368,7 @@ def export_kmc(adata: AnnData) -> None:
         "W_inv": kmc.W_inv,
         "Kd": kmc.Kd,
     }
-    adata.uns.pop("kmc")
+    adata.uns.pop("kmc", None)
 
 
 def import_kmc(adata: AnnData) -> None:

--- a/tests/test_data_io.py
+++ b/tests/test_data_io.py
@@ -112,3 +112,17 @@ def test_save_adata():
 
     dyn.vf.rank_jacobian_genes(adata, groups="leiden")
     adata.write_h5ad("debug11.h5ad")
+
+
+def test_export_kmc_no_kmc():
+    """export_kmc should not raise when no `kmc` object is present."""
+    import anndata
+    import numpy as np
+
+    from dynamo.data_io import export_kmc
+
+    adata = anndata.AnnData(np.ones((5, 3), dtype=float))
+    # no `kmc` in uns -> should be a no-op (no KeyError, no kmc_params created)
+    export_kmc(adata)
+    assert "kmc_params" not in adata.uns
+    assert "kmc" not in adata.uns


### PR DESCRIPTION
Reimplements the intent of #634 (closed: stale, and the original diff had an inverted condition) on current master.

## Summary
`export_kmc` accessed `adata.uns["kmc"]` unconditionally, raising `KeyError` if no kmc object exists. Now it uses `adata.uns.get("kmc")`; when absent it logs and returns without creating `kmc_params`. Fixes the logic bug in the original #634 (which logged "empty" when kmc *existed* and would dereference `None` otherwise).

## Validation
Verified locally: calling `export_kmc` on an AnnData with no `kmc` no longer raises and creates no `kmc_params`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AD7gAdxa3Zt5uiQVDoANa5