### PR TITLE
Fix matplotlib 3D vector plots (cell_wise_vectors_3d)

### DIFF
--- a/dynamo/plot/scatters.py
+++ b/dynamo/plot/scatters.py
@@ -2239,7 +2239,13 @@ def scatters_single_input(
 
     # if #total_panel is 1, `_matplotlib_points` will create a figure. No need to create a figure here and generate a blank figure.
     if ax is None:
-        figure, ax = plt.subplots(figsize=figsize, facecolor=background)
+        if projection == "3d":
+            # a 3d projection must be requested at axes-creation time, otherwise the
+            # downstream 3d scatter receives a 2d axes and z is mis-parsed as `s`.
+            figure = plt.figure(figsize=figsize, facecolor=background)
+            ax = figure.add_subplot(111, projection="3d")
+        else:
+            figure, ax = plt.subplots(figsize=figsize, facecolor=background)
 
     color_out = None
 
@@ -2485,7 +2491,8 @@ def scatters_single_input(
                     "_adata does not seem to have %s column. Velocity estimation is required "
                     "before running this function." % group_k_name
                 )
-    if arrow:
+    if arrow and projection != "3d":
+        # arrowed spines are a 2d concept; `add_arrow` uses 2d `ax.text`, which is invalid on a 3d axes.
         from .utils import add_arrow
         basis_key = 'X_'+basis if basis not in adata.obsm.keys() else basis
         add_arrow(ax, adata, basis_key,arrow_scale=arrow_scale,arrow_width=arrow_width)

--- a/tests/test_pl.py
+++ b/tests/test_pl.py
@@ -264,3 +264,25 @@ def test_preprocess(adata):
     ax = dyn.pl.highest_frac_genes(adata)
     assert isinstance(ax, plt.Axes)
 
+
+
+def test_cell_wise_vectors_3d_matplotlib():
+    """Regression test: the matplotlib 3D vector plot must build a 3d axes without the
+    `scatter() got multiple values for 's'` / `Axes3D.text missing z` errors."""
+    import matplotlib
+    matplotlib.use("Agg")
+    import anndata
+    import numpy as np
+    from mpl_toolkits.mplot3d import Axes3D
+
+    n = 60
+    adata = anndata.AnnData(np.random.default_rng(0).poisson(1.0, (n, 5)).astype(float))
+    adata.obsm["X_umap"] = np.random.default_rng(1).standard_normal((n, 3))
+    adata.obsm["velocity_umap"] = np.random.default_rng(2).standard_normal((n, 3))
+    adata.obs["group"] = (np.arange(n) % 3).astype(str)
+
+    axes = dyn.pl.cell_wise_vectors_3d(
+        adata, basis="umap", color=["group"], plot_method="matplotlib", save_show_or_return="return"
+    )
+    ax = axes[0] if isinstance(axes, (list, tuple)) else axes
+    assert isinstance(ax, Axes3D)


### PR DESCRIPTION
## Summary
`dyn.pl.cell_wise_vectors_3d(..., plot_method="matplotlib")` was broken for the common single-panel case:
1. `TypeError: Axes.scatter() got multiple values for argument 's'`, then
2. `TypeError: Axes3D.text() missing 1 required positional argument: 'z'`.

## Root cause (both in `scatters_single_input`)
- When `ax is None`, the axes was created via `plt.subplots()` (always 2d), **ignoring `projection="3d"`**. The downstream 3d scatter `ax.scatter(x, y, z, s=..., ...)` then received a *2d* axes, so the `z` column was consumed as the positional `s`, colliding with the keyword `s`.
- Arrowed spines (`add_arrow`) call 2d `ax.text(x, y, s=...)`, which is invalid on a 3d axes.

## Fix
- Create a 3d axes (`figure.add_subplot(111, projection="3d")`) when `projection == "3d"`.
- Skip arrowed spines when `projection == "3d"` (they are a 2d concept).

Both changes are guarded by `projection == "3d"`, so 2d plotting is unchanged.

## Validation
- `tests/test_pl.py::test_cell_wise_vectors_3d_matplotlib` (new) passes.
- Verified end-to-end on pancreatic endocrinogenesis (3-component UMAP + projected velocity): the 3d quiver now renders.
- 2d `dyn.pl.scatters` / `umap` confirmed unaffected.

This revives the matplotlib path of the 3D-visualization feature originally proposed in #260.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AD7gAdxa3Zt5uiQVDoANa5