### PR TITLE
docs: add simulation and 3D visualization tutorials to the gallery

### DIFF
--- a/docs/tutorials/index_gallery.md
+++ b/docs/tutorials/index_gallery.md
@@ -11,5 +11,7 @@ Welcome to the dynamo tutorial gallery. If you have any new analysis results wor
 :maxdepth: 1
 
 notebooks/pancreatic_endocrinogenesis
+notebooks/600_simulation_tutorial
+notebooks/610_3d_velocity_visualization
 
 ```


### PR DESCRIPTION
## Summary
Surfaces the two new tutorials in the docs **Tutorial gallery**:
- `notebooks/600_simulation_tutorial` — *Simulating single-cell data with dynamo*
- `notebooks/610_3d_velocity_visualization` — *3D visualization in dynamo*

Two changes:
1. Add both to the gallery toctree in `docs/tutorials/index_gallery.md`.
2. Bump the `docs/tutorials/notebooks` submodule (→ `aristoteleo/dynamo-tutorials`) to the latest master (`92aa4ee`), which contains the two notebooks.

`nb_execution_mode = "off"`, so the build renders the notebooks' embedded outputs (static images on all viewers; interactive Plotly/PyVista scenes render in the readthedocs HTML).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AD7gAdxa3Zt5uiQVDoANa5