### PR TITLE
changelog: credit @Ukyeon (#499) for the steady-state estimation perf fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release Notes
 
+## Dynamo (unreleased)
+
+### Performance
+
+- ~10x faster default (single-core) steady-state RNA-velocity estimation: store `ss_estimation`
+  count layers as CSR so per-gene row indexing is `O(row nnz)` instead of `O(total nnz)` on CSC;
+  results are bit-for-bit identical ([PR 757](https://github.com/aristoteleo/dynamo-release/pull/757)).
+  The performance issue was originally raised by @Ukyeon in
+  [PR 499](https://github.com/aristoteleo/dynamo-release/pull/499).
+
 ## Dynamo Ver 1.4.1
 
 ### DEBUG


### PR DESCRIPTION
Adds a CHANGELOG entry for the CSR steady-state estimation speedup (#757), explicitly crediting @Ukyeon, who originally raised the single-core performance issue in #499.

(The chosen fix differs from #499's approach — see #757 for the analysis — but the performance problem it identified is what motivated the work, and that contribution is acknowledged here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AD7gAdxa3Zt5uiQVDoANa5