### PR TITLE
Fix cell_velocities transition-gene selection with a boolean mask (closes #638)

### DIFF
--- a/dynamo/tools/cell_velocities.py
+++ b/dynamo/tools/cell_velocities.py
@@ -333,7 +333,11 @@ def cell_velocities(
         main_info(f"{X.shape[1] - sum(finite_inds)} genes are removed because of nan velocity values.")
         X, V = X[:, finite_inds], V[:, finite_inds]
         if transition_genes is not None:  # if X, V is provided by the user, transition_genes will be None
-            adata.var.loc[np.array(transition_genes)[~finite_inds], "use_for_transition"] = False
+            # `finite_inds` is aligned with the transition-gene columns of V. Derive those genes from
+            # `use_for_transition` (set consistently above for name-list and boolean-mask inputs) rather
+            # than indexing `transition_genes` directly, which may be a length-n_vars boolean mask.
+            transition_gene_names = adata.var_names[adata.var["use_for_transition"].values]
+            adata.var.loc[transition_gene_names[~finite_inds], "use_for_transition"] = False
 
     if finite_inds.sum() < 5 and len(finite_inds) > 100:
         raise Exception(

--- a/tests/test_tl.py
+++ b/tests/test_tl.py
@@ -461,3 +461,30 @@ def test_ss_estimation_stores_csr():
     # values preserved exactly by the format conversion
     assert np.array_equal(est.data["uu"].toarray(), U.toarray())
     assert np.array_equal(est.data["su"].toarray(), S.toarray())
+
+
+# The following two cell_velocities tests were contributed by @Baschdl in PR #638 to expose a
+# transition-gene selection bug (a length-n_vars boolean mask crashed on `finite_inds` indexing).
+# The bug is fixed in cell_velocities; both cases now pass.
+def _setup_cell_velocities_tests():
+    adata = dyn.sample_data.DentateGyrus_scvelo()[:200, :1000]
+    from dynamo.preprocessing import Preprocessor
+
+    Preprocessor().preprocess_adata(adata, recipe="monocle")
+    dyn.tl.dynamics(adata, model="stochastic")
+    dyn.tl.reduceDimension(adata)
+    return adata
+
+
+def test_cell_velocities():
+    adata = _setup_cell_velocities_tests()
+    dyn.tl.cell_velocities(adata)
+    assert "velocity_S" in adata.layers
+
+
+def test_cell_velocities_selecting_transition_genes():
+    adata = _setup_cell_velocities_tests()
+    # a length-n_vars boolean mask must not crash (regression for PR #638)
+    dyn.tl.cell_velocities(adata, transition_genes=[True] * adata.n_vars)
+    assert "velocity_S" in adata.layers
+    assert adata.var["use_for_transition"].sum() > 0


### PR DESCRIPTION
## Summary
Fixes the bug that **#638** (by @Baschdl) documented with a failing test: passing `transition_genes` as a length-`n_vars` boolean mask to `dyn.tl.cell_velocities` crashes.

## Reproduction (current master)
```python
dyn.tl.cell_velocities(adata, transition_genes=[True] * adata.n_vars)
# IndexError: boolean index did not match indexed array along axis 0;
# size of axis is 1000 but size of corresponding boolean axis is 845
```

## Root cause
When some transition genes have NaN velocity, `cell_velocities` drops them and marks them `use_for_transition = False`:
```python
adata.var.loc[np.array(transition_genes)[~finite_inds], "use_for_transition"] = False
```
`finite_inds` (`= get_finite_inds(V)`) is aligned with **V's transition-gene columns** (845 = `use_for_dynamics`), but `transition_genes` here can be a length-`n_vars` boolean mask (1000). The `[~finite_inds]` index then mismatches. (This is the `dynamics_genes` / `transition_genes` interplay noted in #638.)

## Fix
Derive the transition-gene names from `use_for_transition` — which is set consistently for all input forms (name list, column name, boolean mask) earlier in the function — instead of indexing the raw `transition_genes`:
```python
transition_gene_names = adata.var_names[adata.var["use_for_transition"].values]
adata.var.loc[transition_gene_names[~finite_inds], "use_for_transition"] = False
```

## Validation
- Both #638 tests now pass (`test_cell_velocities`, `test_cell_velocities_selecting_transition_genes`).
- **Default path (`transition_genes=None`) is bit-identical** to master: `use_for_transition` identical and `velocity_umap` identical (`max|Δ| = 0`). In that path `transition_genes` already equals `adata.var_names[use_for_transition]`, so the derived names match exactly.
- No regression: storage/selection logic only.

Closes #638. Tests contributed by @Baschdl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AD7gAdxa3Zt5uiQVDoANa5